### PR TITLE
fix(ci): setup to cross compile with CGO enabled

### DIFF
--- a/.github/workflows/manual_test_build.yml
+++ b/.github/workflows/manual_test_build.yml
@@ -3,8 +3,8 @@
 # This uploads the zip release bundle to `transfer.sh`. Where it will remain for 14 days.
 # NOTE: This file can be overwritten so be cautious when downloading.
 # The idea behind this process is to avoid publishing a test version to our Github Release page.
-on: push
-  # workflow_dispatch:
+on:
+  workflow_dispatch:
 
 jobs:
   check_actor:


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Our binary needs to have been compiled with `CGO` enabled, otherwise, the binary fails to run.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

I installed an arm compiler and arm c libraries.
I then changed from using the `ignite` action, since it was a separate container and was causing issues with finding tools that were installed.
I enabled `CGO` and messed with some other flags to tell Golang to use ARM.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

Tested by temporarily changing the mechanism for triggering to `on: push` to see if it works.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

None.
