### PR TITLE
fix(staking): Fix issue where the staking power could overflow

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"os"
 	"path/filepath"
 
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
+	sdkmath "cosmossdk.io/math"
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/libs/log"
@@ -207,6 +209,8 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+
+	sdk.DefaultPowerReduction = sdkmath.NewIntFromBigInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(appparams.SedaExponent), nil))
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+Name)
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

When staking a few million tokens on a given validator, the node crashes due an integer overflow.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Reduce the `DefaultPowerReduction` taken into account the seda exponent

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

closes #24 
