### PR TITLE
feat: gov-controlled Overlay Wasms

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -566,6 +566,7 @@ func NewApp(
 	app.WasmStorageKeeper = *wasmstoragekeeper.NewKeeper(
 		appCodec,
 		keys[wasmstoragetypes.StoreKey],
+		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 	wasmStorageModule := wasmstorage.NewAppModule(appCodec, app.WasmStorageKeeper, app.AccountKeeper, app.BankKeeper)
 

--- a/app/app.go
+++ b/app/app.go
@@ -258,7 +258,7 @@ type App struct {
 	ScopedICAHostKeeper  capabilitykeeper.ScopedKeeper
 	ScopedWasmKeeper     capabilitykeeper.ScopedKeeper
 
-	SedachainKeeper wasmstoragekeeper.Keeper
+	WasmStorageKeeper wasmstoragekeeper.Keeper
 	// this line is used by starport scaffolding # stargate/app/keeperDeclaration
 
 	// mm is the module manager
@@ -563,11 +563,11 @@ func NewApp(
 		),
 	)
 
-	app.SedachainKeeper = *wasmstoragekeeper.NewKeeper(
+	app.WasmStorageKeeper = *wasmstoragekeeper.NewKeeper(
 		appCodec,
 		keys[wasmstoragetypes.StoreKey],
 	)
-	sedachainModule := wasmstorage.NewAppModule(appCodec, app.SedachainKeeper, app.AccountKeeper, app.BankKeeper)
+	wasmStorageModule := wasmstorage.NewAppModule(appCodec, app.WasmStorageKeeper, app.AccountKeeper, app.BankKeeper)
 
 	// this line is used by starport scaffolding # stargate/app/keeperDefinition
 
@@ -626,7 +626,7 @@ func NewApp(
 		params.NewAppModule(app.ParamsKeeper),
 		transferModule,
 		icaModule,
-		sedachainModule,
+		wasmStorageModule,
 		// this line is used by starport scaffolding # stargate/app/appModule
 
 		crisis.NewAppModule(app.CrisisKeeper, skipGenesisInvariants, nil), // always be last to make sure that it checks for all invariants and not only part of them

--- a/scripts/local_setup.sh
+++ b/scripts/local_setup.sh
@@ -14,9 +14,13 @@ $BIN tendermint unsafe-reset-all
 rm -rf ~/.seda-chain
 $BIN init new node0
 
+cat $HOME/.seda-chain/config/genesis.json | jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' > $HOME/.seda-chain/config/tmp_genesis.json && mv $HOME/.seda-chain/config/tmp_genesis.json $HOME/.seda-chain/config/genesis.json
+cat $HOME/.seda-chain/config/genesis.json | jq '.app_state["gov"]["params"]["voting_period"]="30s"' > $HOME/.seda-chain/config/tmp_genesis.json && mv $HOME/.seda-chain/config/tmp_genesis.json $HOME/.seda-chain/config/genesis.json
+
+
 $BIN keys add satoshi --keyring-backend test
 ADDR=$($BIN keys show satoshi --keyring-backend test -a)
-$BIN add-genesis-account $ADDR 10000000000000000seda
+$BIN add-genesis-account $ADDR 100000000000000000seda --keyring-backend test
 $BIN gentx satoshi 10000000000000000seda --keyring-backend test
 $BIN collect-gentxs
 $BIN start

--- a/x/wasm-storage/client/cli/gov_tx.go
+++ b/x/wasm-storage/client/cli/gov_tx.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/address"
+	"github.com/cosmos/cosmos-sdk/x/gov/client/cli"
+	v1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/sedaprotocol/seda-chain/x/wasm-storage/types"
+)
+
+// DefaultGovAuthority is set to the gov module address.
+// Extension point for chains to overwrite the default
+var DefaultGovAuthority = sdk.AccAddress(address.Module("gov"))
+
+const flagAuthority = "authority"
+
+func SubmitProposalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "submit-proposal",
+		Short:        "Submit a wasm proposal.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(
+		ProposalStoreCodeCmd(),
+	)
+	return cmd
+}
+
+func ProposalStoreCodeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "store-overlay-wasm [wasm file] --wasm-type [wasm_type] --title [text] --summary [text] --authority [address]",
+		Short: "Submit a proposal to store a new Overlay Wasm",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, proposalTitle, summary, deposit, err := getProposalInfo(cmd)
+			if err != nil {
+				return err
+			}
+
+			authority, err := cmd.Flags().GetString(flagAuthority)
+			if err != nil {
+				return fmt.Errorf("authority: %s", err)
+			}
+			if len(authority) == 0 {
+				return errors.New("authority address is required")
+			}
+
+			src, err := parseStoreCodeArgs(args[0], authority, cmd.Flags())
+			if err != nil {
+				return err
+			}
+
+			proposalMsg, err := v1.NewMsgSubmitProposal([]sdk.Msg{&src}, deposit, clientCtx.GetFromAddress().String(), "", proposalTitle, summary)
+			if err != nil {
+				return err
+			}
+			if err = proposalMsg.ValidateBasic(); err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), proposalMsg)
+		},
+		SilenceUsage: true,
+	}
+
+	cmd.Flags().String(FlagWasmType, "", "Overlay Wasm type: data-request-executor or relayer")
+	cmd.MarkFlagRequired(FlagWasmType)
+	// proposal flags
+	addCommonProposalFlags(cmd)
+	return cmd
+}
+
+func parseStoreCodeArgs(file string, sender string, flags *flag.FlagSet) (types.MsgStoreOverlayWasm, error) {
+	zipped, err := gzipWasmFile(file)
+	if err != nil {
+		return types.MsgStoreOverlayWasm{}, err
+	}
+
+	msg := types.MsgStoreOverlayWasm{
+		Sender:   sender,
+		Wasm:     zipped,
+		WasmType: types.WasmTypeFromString(viper.GetString(FlagWasmType)),
+	}
+	return msg, nil
+}
+
+func addCommonProposalFlags(cmd *cobra.Command) {
+	flags.AddTxFlagsToCmd(cmd)
+	cmd.Flags().String(cli.FlagTitle, "", "Title of proposal")
+	cmd.Flags().String(cli.FlagSummary, "", "Summary of proposal")
+	cmd.Flags().String(cli.FlagDeposit, "", "Deposit of proposal")
+	cmd.Flags().String(flagAuthority, DefaultGovAuthority.String(), "The address of the governance account. Default is the sdk gov module account")
+}
+
+func getProposalInfo(cmd *cobra.Command) (client.Context, string, string, sdk.Coins, error) {
+	clientCtx, err := client.GetClientTxContext(cmd)
+	if err != nil {
+		return client.Context{}, "", "", nil, err
+	}
+
+	proposalTitle, err := cmd.Flags().GetString(cli.FlagTitle)
+	if err != nil {
+		return clientCtx, proposalTitle, "", nil, err
+	}
+
+	summary, err := cmd.Flags().GetString(cli.FlagSummary)
+	if err != nil {
+		return client.Context{}, proposalTitle, summary, nil, err
+	}
+
+	depositArg, err := cmd.Flags().GetString(cli.FlagDeposit)
+	if err != nil {
+		return client.Context{}, proposalTitle, summary, nil, err
+	}
+
+	deposit, err := sdk.ParseCoinsNormalized(depositArg)
+	if err != nil {
+		return client.Context{}, proposalTitle, summary, deposit, err
+	}
+
+	return clientCtx, proposalTitle, summary, deposit, nil
+}

--- a/x/wasm-storage/client/cli/tx.go
+++ b/x/wasm-storage/client/cli/tx.go
@@ -29,7 +29,6 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		GetCmdStoreDataRequestWasm(),
-		GetCmdStoreOverlayWasm(),
 		SubmitProposalCmd(),
 	)
 	return cmd
@@ -62,38 +61,6 @@ func GetCmdStoreDataRequestWasm() *cobra.Command {
 	}
 
 	cmd.Flags().String(FlagWasmType, "", "Data Request Wasm type: data-request or tally")
-	cmd.MarkFlagRequired(FlagWasmType)
-	flags.AddTxFlagsToCmd(cmd)
-	return cmd
-}
-
-// GetCmdStoreOverlayWasm returns the command for storing Overlay Wasm.
-func GetCmdStoreOverlayWasm() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "store-overlay-wasm <filename>",
-		Short: "Store Overlay Wasm file",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			clientCtx, err := client.GetClientTxContext(cmd)
-			if err != nil {
-				return err
-			}
-
-			wasm, err := gzipWasmFile(args[0])
-			if err != nil {
-				return err
-			}
-
-			msg := &types.MsgStoreOverlayWasm{
-				Sender:   clientCtx.GetFromAddress().String(),
-				Wasm:     wasm,
-				WasmType: types.WasmTypeFromString(viper.GetString(FlagWasmType)),
-			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
-		},
-	}
-
-	cmd.Flags().String(FlagWasmType, "", "Overlay Wasm type: data-request-executor or relayer")
 	cmd.MarkFlagRequired(FlagWasmType)
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd

--- a/x/wasm-storage/client/cli/tx.go
+++ b/x/wasm-storage/client/cli/tx.go
@@ -27,8 +27,11 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(GetCmdStoreDataRequestWasm())
-	cmd.AddCommand(GetCmdStoreOverlayWasm())
+	cmd.AddCommand(
+		GetCmdStoreDataRequestWasm(),
+		// GetCmdStoreOverlayWasm(),
+		SubmitProposalCmd(),
+	)
 	return cmd
 }
 
@@ -64,6 +67,7 @@ func GetCmdStoreDataRequestWasm() *cobra.Command {
 	return cmd
 }
 
+/*
 // GetCmdStoreOverlayWasm returns the command for storing Overlay Wasm.
 func GetCmdStoreOverlayWasm() *cobra.Command {
 	cmd := &cobra.Command{
@@ -95,6 +99,7 @@ func GetCmdStoreOverlayWasm() *cobra.Command {
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
+*/
 
 func gzipWasmFile(filename string) ([]byte, error) {
 	wasm, err := os.ReadFile(filename)

--- a/x/wasm-storage/client/cli/tx.go
+++ b/x/wasm-storage/client/cli/tx.go
@@ -29,7 +29,7 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		GetCmdStoreDataRequestWasm(),
-		// GetCmdStoreOverlayWasm(),
+		GetCmdStoreOverlayWasm(),
 		SubmitProposalCmd(),
 	)
 	return cmd
@@ -67,7 +67,6 @@ func GetCmdStoreDataRequestWasm() *cobra.Command {
 	return cmd
 }
 
-/*
 // GetCmdStoreOverlayWasm returns the command for storing Overlay Wasm.
 func GetCmdStoreOverlayWasm() *cobra.Command {
 	cmd := &cobra.Command{
@@ -99,7 +98,6 @@ func GetCmdStoreOverlayWasm() *cobra.Command {
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }
-*/
 
 func gzipWasmFile(filename string) ([]byte, error) {
 	wasm, err := os.ReadFile(filename)

--- a/x/wasm-storage/keeper/keeper.go
+++ b/x/wasm-storage/keeper/keeper.go
@@ -14,14 +14,16 @@ import (
 )
 
 type Keeper struct {
-	cdc      codec.BinaryCodec
-	storeKey storetypes.StoreKey
+	cdc       codec.BinaryCodec
+	storeKey  storetypes.StoreKey
+	authority string
 }
 
-func NewKeeper(cdc codec.BinaryCodec, storeKey storetypes.StoreKey) *Keeper {
+func NewKeeper(cdc codec.BinaryCodec, storeKey storetypes.StoreKey, authority string) *Keeper {
 	return &Keeper{
-		cdc:      cdc,
-		storeKey: storeKey,
+		cdc:       cdc,
+		storeKey:  storeKey,
+		authority: authority,
 	}
 }
 

--- a/x/wasm-storage/keeper/msg_server.go
+++ b/x/wasm-storage/keeper/msg_server.go
@@ -26,10 +26,6 @@ var _ types.MsgServer = msgServer{}
 func (k msgServer) StoreDataRequestWasm(goCtx context.Context, msg *types.MsgStoreDataRequestWasm) (*types.MsgStoreDataRequestWasmResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if msg.Sender != k.authority {
-		return nil, fmt.Errorf("invalid authority %s", msg.Sender)
-	}
-
 	unzipped := unzipWasm(msg.Wasm)
 	wasm := types.NewWasm(unzipped, msg.WasmType, ctx.BlockTime())
 	if k.Keeper.HasDataRequestWasm(ctx, wasm) {
@@ -53,6 +49,10 @@ func (k msgServer) StoreDataRequestWasm(goCtx context.Context, msg *types.MsgSto
 
 func (k msgServer) StoreOverlayWasm(goCtx context.Context, msg *types.MsgStoreOverlayWasm) (*types.MsgStoreOverlayWasmResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if msg.Sender != k.authority {
+		return nil, fmt.Errorf("invalid authority %s", msg.Sender)
+	}
 
 	unzipped := unzipWasm(msg.Wasm)
 	wasm := types.NewWasm(unzipped, msg.WasmType, ctx.BlockTime())

--- a/x/wasm-storage/keeper/msg_server.go
+++ b/x/wasm-storage/keeper/msg_server.go
@@ -26,6 +26,10 @@ var _ types.MsgServer = msgServer{}
 func (k msgServer) StoreDataRequestWasm(goCtx context.Context, msg *types.MsgStoreDataRequestWasm) (*types.MsgStoreDataRequestWasmResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	if msg.Sender != k.authority {
+		return nil, fmt.Errorf("invalid authority %s", msg.Sender)
+	}
+
 	unzipped := unzipWasm(msg.Wasm)
 	wasm := types.NewWasm(unzipped, msg.WasmType, ctx.BlockTime())
 	if k.Keeper.HasDataRequestWasm(ctx, wasm) {


### PR DESCRIPTION
## Explanation of Changes

This PR replaces the existing transaction endpoint for sending an `sdk.Msg` for storing an Overlay Wasm binary with a governance proposal submission endpoint that wraps this message. As a result, any updates in the Overlay Wasm bucket now require going through governance voting process. By default settings, a proposal is passed with 1/3 of voters weighted by their stakes voting and a majority yes.

## Testing

Manually tested in local setting. The local setup script was updated so that voting period is short (30 seconds).

After setting up the chain with `scripts/local_setup.sh`, run the following commands to submit a proposal and vote yes.
```
$ seda-chaind tx wasm-storage submit-proposal store-overlay-wasm <wasm_file> --wasm-type relayer --title <title> --summary <summary> --deposit 10000000aseda --from <test_key_addr> --keyring-backend test --gas auto --gas-adjustment 1.2 -y

$ seda-chaind tx gov vote 1 yes --from <test_key_addr> --keyring-backend test --gas auto --gas-adjustment 1.2 -y

# after 30 seconds, the Wasm should appear on the list
$ seda-chaind query wasm-storage list-overlay-wasms
```

## Related PRs and Issues

Closes #44
