### PR TITLE
refactor: improve init command

### DIFF
--- a/cmd/seda-chaind/cmd/init_cmds.go
+++ b/cmd/seda-chaind/cmd/init_cmds.go
@@ -61,10 +61,13 @@ func newNetworkCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Comma
 			config := serverCtx.Config
 			config.SetRoot(clientCtx.HomeDir)
 
-			recover, _ := cmd.Flags().GetBool(FlagRecover)
-			mnemonic, err := validateOrGenerateMnemonic(recover, cmd)
-			if err != nil {
-				return err
+			var mnemonic string
+			var err error
+			if recover, _ := cmd.Flags().GetBool(FlagRecover); recover {
+				mnemonic, err = readInMnemonic(cmd)
+				if err != nil {
+					return err
+				}
 			}
 
 			// get chain ID
@@ -148,10 +151,13 @@ func joinNetworkCommand(mbm module.BasicManager, defaultNodeHome string) *cobra.
 			config := serverCtx.Config
 			config.SetRoot(clientCtx.HomeDir)
 
-			recover, _ := cmd.Flags().GetBool(FlagRecover)
-			mnemonic, err := validateOrGenerateMnemonic(recover, cmd)
-			if err != nil {
-				return err
+			var mnemonic string
+			var err error
+			if recover, _ := cmd.Flags().GetBool(FlagRecover); recover {
+				mnemonic, err = readInMnemonic(cmd)
+				if err != nil {
+					return err
+				}
 			}
 
 			network, _ := cmd.Flags().GetString(FlagNetwork)
@@ -163,6 +169,12 @@ func joinNetworkCommand(mbm module.BasicManager, defaultNodeHome string) *cobra.
 				}
 			} else {
 				return fmt.Errorf("unsupported network type: %s", network)
+			}
+
+			// configure validator files
+			err = configureValidatorFiles(config)
+			if err != nil {
+				return err
 			}
 
 			// initialize the node


### PR DESCRIPTION
## Motivation

Closes #70 
Joint work with @mennatabuelnaga 

## Explanation of Changes

- `init network` command has been renamed to `init join`
- `init join` now fetches seeds information, if it can be found in the seda-networks repo, and updates the chain configuration file `config.toml`.

## Testing
Make sure your chain directory is empty and run 
```
$ seda-chaind init join <moniker> --network devnet # devnet or localnet
$ seda-chaind start
```
Then the chain will sync to the current block height. Two simple commands sets up a full node!

