### PR TITLE
CI: Add Lint & Gosec; Overall Cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,56 @@
+---
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  GO_VERSION: "1.21.0"
+  GOPRIVATE: github.com/sedaprotocol/vrf-go
+  GITHUB_TOKEN: ${{ secrets.PAT }}
+
+permissions:
+  contents: read
+  repository-projects: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        targetos: [darwin, linux]
+    name: ${{ matrix.targetos }}-${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache Go modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+        env:
+          GOOS: ${{ matrix.targetos }}
+          GOARCH: ${{ matrix.arch }}
+      - name: Configure private token
+        run: |
+          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+      - name: Compile
+        run: |
+          go mod download
+          make build

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,31 @@
+name: Gosec
+
+on:
+  push:
+    branches:
+      - release/*
+  pull_request:
+    branches:
+      - release/*
+
+permissions:
+  contents: read
+  repository-projects: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: informalsystems/gosec@master
+        with:
+          args: -exclude-dir=cmd,tools ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+
+permissions:
+  contents: read
+  repository-projects: read
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest
+          args: --timeout 10m --tests=false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,15 @@
-name: Tests / Code Coverage
+name: Tests
+
 on:
   push:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
-  merge_group:
-    types: [checks_requested]
+
+env:
+  GO_VERSION: "1.21.0"
+  GOPRIVATE: github.com/sedaprotocol/vrf-go
+  GITHUB_TOKEN: ${{ secrets.PAT }}
 
 permissions:
   contents: read
@@ -18,100 +21,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  unit-tests:
     runs-on: ubuntu-latest
-    env:
-      GOPRIVATE: github.com/sedaprotocol/vrf-go
-      GITHUB_TOKEN: ${{ secrets.PAT }}
-    strategy:
-      matrix:
-        arch: [amd64, arm64]
-        targetos: [darwin, linux]
-    name: sedad ${{ matrix.targetos }}-${{ matrix.arch }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Cache binaries
-        id: cache-binaries
-        uses: actions/cache@v3
-        with:
-          path: ./cmd/sedad/sedad
-          key: sedad-${{ matrix.targetos }}-${{ matrix.arch }}
-      - uses: technote-space/get-diff-action@v6.1.2
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
-      - name: Setup go
-        if: steps.cache-binaries.outputs.cache-hit != 'true' && env.GIT_DIFF
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-          cache: true
-        env:
-          GOOS: ${{ matrix.targetos }}
-          GOARCH: ${{ matrix.arch }}
-      - name: Configure private token
-        run: |
-          git config --global url."https://${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-      - name: Compile
-        if: steps.cache-binaries.outputs.cache-hit != 'true' && env.GIT_DIFF
-        run: |
-          go mod download
-          make build
-
-  tests:
-    runs-on: ubuntu-latest
-    env:
-      GOPRIVATE: github.com/sedaprotocol/vrf-go
-      GITHUB_TOKEN: ${{ secrets.PAT }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: true
           cache-dependency-path: go.sum
       - run: git config --global url.https://${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            **/Makefile
-            Makefile
       - name: Test & coverage report creation
-        if: env.GIT_DIFF
         run: make test-unit-cover
       - uses: actions/upload-artifact@v3
-        if: env.GIT_DIFF
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-coverage"
           path: ./${{ matrix.part }}profile.out
 
-  test-e2e:
+  e2e-tests:
     runs-on: ubuntu-latest
-    env:
-      GOPRIVATE: github.com/sedaprotocol/vrf-go
-      GITHUB_TOKEN: ${{ secrets.PAT }}
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
-      - uses: actions/checkout@v4
+          go-version: ${{ env.GO_VERSION }}
       - run: git config --global url.https://${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/
-      - uses: technote-space/get-diff-action@v6.0.1
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - name: Test e2e
         run: |
           make test-e2e


### PR DESCRIPTION
## Overview

This PR attempts to refine the existing CI flows by performing the following:
- Separate Build from Tests
- Remove get-diff-action which brings little to no value
- Avoid double-runs on each push on a pull request
- Refined trigger conditions
- Add golangci-lint
- Add gosec that only runs on release branches

⚠️ **Note golangci-lint won't pass until we fix all reported findings. This will be taken care of in a future PR.**