### PR TITLE
Fix CI Double Runs on PR Merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   GO_VERSION: "1.21.0"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
   push:
     tags:
       - v*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   GO_VERSION: "1.21.0"


### PR DESCRIPTION
## Overview
We are currently seeing double runs when PR's are merged into main because a merge triggers a `push` event as well as a `pull_request` event.

This PR fixes it by explicitly specifying the the types of `pull_request `events that should trigger the workflow.

## Reference
![image](https://github.com/sedaprotocol/seda-chain/assets/31609693/0d95dd96-fc41-4ece-9290-6d5db2904913)
