### PR TITLE
fix: add textual sign mode and fix query node flags

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -52,13 +52,16 @@ import (
 	"github.com/cosmos/cosmos-sdk/std"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	sigtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
 	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
+	txmodule "github.com/cosmos/cosmos-sdk/x/auth/tx/config"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
@@ -380,6 +383,21 @@ func NewApp(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 		logger,
 	)
+
+	// optional: enable sign mode textual by overwriting the default tx config (after setting the bank keeper)
+	enabledSignModes := append(tx.DefaultSignModes, sigtypes.SignMode_SIGN_MODE_TEXTUAL)
+	txConfigOpts := tx.ConfigOptions{
+		EnabledSignModes:           enabledSignModes,
+		TextualCoinMetadataQueryFn: txmodule.NewBankKeeperCoinMetadataQueryFn(app.BankKeeper),
+	}
+	txConfig, err = tx.NewTxConfigWithOptions(
+		appCodec,
+		txConfigOpts,
+	)
+	if err != nil {
+		panic(err)
+	}
+	app.txConfig = txConfig
 
 	app.StakingKeeper = stakingkeeper.NewKeeper(
 		appCodec,

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -4,11 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/std"
-	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 )
-
-var encodingConfig = initEncodingConfig()
 
 // EncodingConfig specifies the concrete encoding types to use for a given app.
 // This is provided for compatibility between protobuf and amino implementations.
@@ -17,37 +13,4 @@ type EncodingConfig struct {
 	Marshaler         codec.Codec
 	TxConfig          client.TxConfig
 	Amino             *codec.LegacyAmino
-}
-
-// GetEncodingConfig returns the EncodingConfig.
-func GetEncodingConfig() EncodingConfig {
-	return encodingConfig
-}
-
-// makeEncodingConfig creates an EncodingConfig for an amino based test configuration.
-func makeEncodingConfig() EncodingConfig {
-	amino := codec.NewLegacyAmino()
-	interfaceRegistry := types.NewInterfaceRegistry()
-	codec := codec.NewProtoCodec(interfaceRegistry)
-	txCfg := tx.NewTxConfig(codec, tx.DefaultSignModes)
-
-	return EncodingConfig{
-		InterfaceRegistry: interfaceRegistry,
-		Marshaler:         codec,
-		TxConfig:          txCfg,
-		Amino:             amino,
-	}
-}
-
-// initEncodingConfig initializes an EncodingConfig.
-func initEncodingConfig() EncodingConfig {
-	encodingConfig := makeEncodingConfig()
-
-	std.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-
-	// ModuleBasics.RegisterLegacyAminoCodec(encodingConfig.Amino)
-	ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
-
-	return encodingConfig
 }

--- a/e2e/chain.go
+++ b/e2e/chain.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/std"
+	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 
 	"github.com/sedaprotocol/seda-chain/app"
 )
@@ -24,7 +27,15 @@ var (
 )
 
 func init() {
-	encodingConfig = app.GetEncodingConfig()
+	encodingConfig.Amino = codec.NewLegacyAmino()
+	encodingConfig.InterfaceRegistry = types.NewInterfaceRegistry()
+	encodingConfig.Marshaler = codec.NewProtoCodec(encodingConfig.InterfaceRegistry)
+	encodingConfig.TxConfig = tx.NewTxConfig(encodingConfig.Marshaler, tx.DefaultSignModes)
+
+	std.RegisterLegacyAminoCodec(encodingConfig.Amino)
+	std.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+	app.ModuleBasics.RegisterInterfaces(encodingConfig.InterfaceRegistry)
+
 	cdc = encodingConfig.Marshaler
 	txConfig = encodingConfig.TxConfig
 }


### PR DESCRIPTION
## Explanation of Changes

This PR adds textual sign mode so that crisis's invariant check tx works (closes #154).
It also adds back query flags that were removed due to some compile error (closes #155).


