### PR TITLE
fix: workflow fix to pass version and commit info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,11 @@ jobs:
 
       - name: 🔨 Build Binaries
         run: |
-          export VERSION=$(echo $(git describe --tags --always --match "v*") | sed 's/^v//')
-          export COMMIT=$(git log -1 --format='%H')
+          export GIT_VERSION=$(echo $(git describe --tags --always --match "v*") | sed 's/^v//')
+          export GIT_COMMIT=$(git log -1 --format='%H')
           docker build -t seda-static -f ./dockerfiles/Dockerfile.build-static \
-            --build-arg VERSION="$VERSION" \
-            --build-arg COMMIT="$COMMIT" .
+            --build-arg GIT_VERSION="$GIT_VERSION" \
+            --build-arg GIT_COMMIT="$GIT_COMMIT" .
           mkdir build
           docker run --rm -v $(pwd)/build:/output seda-static cp -r /build/. /output/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,11 @@ jobs:
 
       - name: 🔨 Build Binaries
         run: |
-          export GIT_VERSION=$(echo $(git describe --tags --always --match "v*") | sed 's/^v//')
-          export GIT_COMMIT=$(git log -1 --format='%H')
+          export VERSION=$(echo $(git describe --tags --always --match "v*") | sed 's/^v//')
+          export COMMIT=$(git log -1 --format='%H')
           docker build -t seda-static -f ./dockerfiles/Dockerfile.build-static \
-            --build-arg GIT_VERSION="$GIT_VERSION" \
-            --build-arg GIT_COMMIT="$GIT_COMMIT" .
+            --build-arg GIT_VERSION="$VERSION" \
+            --build-arg GIT_COMMIT="$COMMIT" .
           mkdir build
           docker run --rm -v $(pwd)/build:/output seda-static cp -r /build/. /output/
 


### PR DESCRIPTION
Closes #168 

The binaries built through Docker was not showing the tag from which they were built when you run the command seda-chaind version. The GitHub workflow was not passing in the arguments to the Dockerfile correctly.