### PR TITLE
Add Support for State Streaming

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -567,6 +567,10 @@ func NewApp(
 		),
 	)
 
+	if err := bApp.RegisterStreamingServices(appOpts, keys); err != nil {
+		panic(err)
+	}
+
 	/* =================================================== */
 	/*                  TRANSFER STACK                     */
 	/* =================================================== */


### PR DESCRIPTION
## Overview
A simple line but enables state streaming if enabled in `app.toml`.
![telegram-cloud-photo-size-1-5010696812918582573-x](https://github.com/sedaprotocol/seda-chain/assets/31609693/2a3616e1-4cf8-4d65-af53-b66c9af2600c)

Closes #141 