### PR TITLE
chore: Script for adding group to genesis state

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ In the output of the above command make sure catching_up is false
 “catching_up”: false
 ```
 
-Create a validator.json file and fill in the create-validator tx parameters:
+Create a `validator.json` file and fill in the create-validator tx parameters:
 
 ```
 {
- "pubkey": {"@type":"/cosmos.crypto.ed25519.PubKey","key":"$(./seda-chaind-${ARCH} tendermint show-validator)"},
+ "pubkey": $(./seda-chaind-${ARCH} tendermint show-validator),
  "amount": "1000000000000000000000000000000000aseda", 
  "moniker": "the moniker for your validator",
  "identity": "optional identity signature (ex. UPort or Keybase) This key will be used by block explorers to identify the validator.",

--- a/scripts/testnet/README.md
+++ b/scripts/testnet/README.md
@@ -7,5 +7,5 @@ Make sure to first create a configuration file named config.sh using the templat
 Run in the following order, one by one:
 
 1. `create_genesis.sh` - Validates validator files for each node and creates a genesis file.
-2. `add_wasm_state_to_genesis.sh` - Runs a chain, deploys Wasm contracts on it, and dumps the Wasm state, which is then added to a given genesis file.
+2. `build_genesis_state.sh` - Runs a chain, deploys Wasm contracts on it, and dumps the Wasm state, which is then added to a given genesis file. Must be used with at least one of the following flags: `--add-groups` and `add-wasm-contracts`.
 3. `upload_and_start.sh` - Uploads and runs setup_node.sh on the nodes to process necessary setups. Then uploads the validator files and genesis and restarts the nodes.

--- a/scripts/testnet/build_genesis_state.sh
+++ b/scripts/testnet/build_genesis_state.sh
@@ -90,6 +90,12 @@ do
 	shift
 done
 
+# at least one flag should be on
+if [ $ADD_WASM_CONTRACTS = false ] && [ $ADD_GROUPS = false ]; then
+    echo "add at least one flag: --add-wasm-contracts or --add-groups"
+    exit 1
+fi
+
 #
 #   PRELIMINARY CHECKS AND DOWNLOADS
 #
@@ -99,8 +105,7 @@ if [ ! -f "$ORIGINAL_GENESIS" ]; then
   exit 1
 fi
 
-TMP_HOME=~/.seda-chain/
-# TMP_HOME=./tmp
+TMP_HOME=./tmp
 rm -rf $TMP_HOME
 
 if [ $ADD_WASM_CONTRACTS = true ]; then
@@ -120,9 +125,15 @@ $LOCAL_BIN init node0 --home $TMP_HOME --chain-id $TEMP_CHAIN_ID --default-denom
 $LOCAL_BIN keys add deployer --home $TMP_HOME --keyring-backend test
 ADDR=$($LOCAL_BIN keys show deployer --home $TMP_HOME --keyring-backend test -a)
 $LOCAL_BIN add-genesis-account $ADDR 100000000000000000seda --home $TMP_HOME --keyring-backend test
+
+if [ $ADD_GROUPS = true ]; then
+  echo $ADMIN_SEED | $LOCAL_BIN keys add admin --home $TMP_HOME --keyring-backend test --recover
+  ADMIN_ADDR=$($LOCAL_BIN keys show admin --home $TMP_HOME --keyring-backend test -a)
+  $LOCAL_BIN add-genesis-account $ADMIN_ADDR 100000000000000000seda --home $TMP_HOME --keyring-backend test
+fi
+
 $LOCAL_BIN gentx deployer 10000000000000000seda --home $TMP_HOME --keyring-backend test --chain-id $TEMP_CHAIN_ID
 $LOCAL_BIN collect-gentxs --home $TMP_HOME
-
 
 $LOCAL_BIN start --home $TMP_HOME > chain_output.log 2>&1 & disown
 
@@ -134,35 +145,25 @@ sleep 20
 #
 
 # Create group and group policy
-
 if [ $ADD_GROUPS = true ]; then
-  echo $ADMIN_SEED | $LOCAL_BIN keys add admin --home $TMP_HOME --keyring-backend test --recover
-  ADMIN_ADDR=$($LOCAL_BIN keys show admin --home $TMP_HOME --keyring-backend test -a)
-  
-  # $LOCAL_BIN tx group create-group $ADMIN_ADDR "ipfs://not_real_metadata" $MEMBERS_JSON_FILE --keyring-backend test --home $TMP_HOME --chain-id $TEMP_CHAIN_ID -y
-  # sleep 10
-  # $LOCAL_BIN tx group create-group-policy $ADMIN_ADDR 1 "{\"name\":\"quick turnaround\",\"description\":\"\"}" $POLICY_JSON_FILE --keyring-backend test --home $TMP_HOME --chain-id $TEMP_CHAIN_ID -y
-  # sleep 10
-
   $LOCAL_BIN tx group create-group-with-policy $ADMIN_ADDR "ipfs://not_real_metadata" "{\"name\":\"quick turnaround\",\"description\":\"\"}" $MEMBERS_JSON_FILE $POLICY_JSON_FILE --home $TMP_HOME --from $ADMIN_ADDR --keyring-backend test --chain-id $TEMP_CHAIN_ID -y
   sleep 10
 fi
 
 
-# # Store and instantiate three contracts
-# PROXY_ADDR=$(store_and_instantiate proxy_contract.wasm '{"token":"aseda"}')
+if [ $ADD_WASM_CONTRACTS = true ]; then
+  # Store and instantiate three contracts
+  PROXY_ADDR=$(store_and_instantiate proxy_contract.wasm '{"token":"aseda"}')
+  ARG='{"token":"aseda", "proxy": "'$PROXY_ADDR'" }'
+  STAKING_ADDR=$(store_and_instantiate staking.wasm "$ARG")
+  DR_ADDR=$(store_and_instantiate data_requests.wasm "$ARG")
 
-# ARG='{"token":"aseda", "proxy": "'$PROXY_ADDR'" }'
-# STAKING_ADDR=$(store_and_instantiate staking.wasm "$ARG")
-# DR_ADDR=$(store_and_instantiate data_requests.wasm "$ARG")
-
-
-# # Call SetStaking and SetDataRequests on Proxy contract to set circular dependency
-# $LOCAL_BIN tx wasm execute $PROXY_ADDR '{"set_staking":{"contract":"'$STAKING_ADDR'"}}' --from $ADDR --gas auto --gas-adjustment 1.2 --keyring-backend test  --home $TMP_HOME --chain-id $TEMP_CHAIN_ID -y
-# sleep 10
-# $LOCAL_BIN tx wasm execute $PROXY_ADDR '{"set_data_requests":{"contract":"'$DR_ADDR'"}}' --from $ADDR --gas auto --gas-adjustment 1.2 --keyring-backend test  --home $TMP_HOME --chain-id $TEMP_CHAIN_ID -y
-# sleep 10
-
+  # Call SetStaking and SetDataRequests on Proxy contract to set circular dependency
+  $LOCAL_BIN tx wasm execute $PROXY_ADDR '{"set_staking":{"contract":"'$STAKING_ADDR'"}}' --from $ADDR --gas auto --gas-adjustment 1.2 --keyring-backend test  --home $TMP_HOME --chain-id $TEMP_CHAIN_ID -y
+  sleep 10
+  $LOCAL_BIN tx wasm execute $PROXY_ADDR '{"set_data_requests":{"contract":"'$DR_ADDR'"}}' --from $ADDR --gas auto --gas-adjustment 1.2 --keyring-backend test  --home $TMP_HOME --chain-id $TEMP_CHAIN_ID -y
+  sleep 10
+fi
 
 #
 #   TERMINATE CHAIN PROCESS, EXPORT, AND MODIFY GIVEN GENESIS
@@ -175,28 +176,38 @@ python3 -m json.tool $TMP_HOME/exported > $TMP_HOME/genesis.json
 rm $TMP_HOME/exported
 
 
-# #
-# # Modify
-# # - wasm.codes
-# # - wasm.contracts
-# # - wasm.sequences
-# # - wasm-storage.proxy_contract_registry
-# #
-# EXPORTED_GENESIS=$TMP_HOME/genesis.json
-# TMP_GENESIS=$TMP_HOME/tmp_genesis.json
-# TMP_TMP_GENESIS=$TMP_HOME/tmp_tmp_genesis.json
+EXPORTED_GENESIS=$TMP_HOME/genesis.json
+TMP_GENESIS=$TMP_HOME/tmp_genesis.json
+TMP_TMP_GENESIS=$TMP_HOME/tmp_tmp_genesis.json
 
-# jq '.app_state["wasm"]["codes"]' $EXPORTED_GENESIS > $TMP_HOME/codes.tmp
-# jq '.app_state["wasm"]["contracts"]' $EXPORTED_GENESIS > $TMP_HOME/contracts.tmp
-# jq '.app_state["wasm"]["sequences"]' $EXPORTED_GENESIS > $TMP_HOME/sequences.tmp
+cp $ORIGINAL_GENESIS $TMP_GENESIS # make adjustments on TMP_GENESIS until replacing original genesis in the last step
 
-# jq '.app_state["wasm-storage"]["proxy_contract_registry"]="'$PROXY_ADDR'"' $ORIGINAL_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
-# jq --slurpfile codes $TMP_HOME/codes.tmp '.app_state["wasm"]["codes"] = $codes[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
-# jq --slurpfile contracts $TMP_HOME/contracts.tmp '.app_state["wasm"]["contracts"] = $contracts[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
-# jq --slurpfile sequences $TMP_HOME/sequences.tmp '.app_state["wasm"]["sequences"] = $sequences[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+# Modify group state and wasm code upload params
+if [ $ADD_GROUPS = true ]; then
+  jq '.app_state["group"]' $EXPORTED_GENESIS > $TMP_HOME/group.tmp
+  GROUP_POLICY_ADDR=$(jq '.app_state["group"]["group_policies"][0]["address"]' $EXPORTED_GENESIS)
 
-# mv $TMP_GENESIS $ORIGINAL_GENESIS
+  jq --slurpfile group $TMP_HOME/group.tmp '.app_state["group"] = $group[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+  jq '.app_state["wasm"]["params"]["code_upload_access"]["permission"]="AnyOfAddresses"' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+  jq '.app_state["wasm"]["params"]["instantiate_default_permission"]="AnyOfAddresses"' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+  jq '.app_state["wasm"]["params"]["code_upload_access"]["addresses"]=['$GROUP_POLICY_ADDR']' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+fi
 
-# # clean up
-# rm -rf $TMP_HOME
-# rm chain_output.log
+# Modify wasm codes, contracts, and sequences. 
+# Also modify wasm-storage's proxy contract registery.
+if [ $ADD_WASM_CONTRACTS = true ]; then
+  jq '.app_state["wasm"]["codes"]' $EXPORTED_GENESIS > $TMP_HOME/codes.tmp
+  jq '.app_state["wasm"]["contracts"]' $EXPORTED_GENESIS > $TMP_HOME/contracts.tmp
+  jq '.app_state["wasm"]["sequences"]' $EXPORTED_GENESIS > $TMP_HOME/sequences.tmp
+
+  jq '.app_state["wasm-storage"]["proxy_contract_registry"]="'$PROXY_ADDR'"' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+  jq --slurpfile codes $TMP_HOME/codes.tmp '.app_state["wasm"]["codes"] = $codes[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+  jq --slurpfile contracts $TMP_HOME/contracts.tmp '.app_state["wasm"]["contracts"] = $contracts[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+  jq --slurpfile sequences $TMP_HOME/sequences.tmp '.app_state["wasm"]["sequences"] = $sequences[0]' $TMP_GENESIS > $TMP_TMP_GENESIS && mv $TMP_TMP_GENESIS $TMP_GENESIS
+fi
+
+mv $TMP_GENESIS $ORIGINAL_GENESIS
+
+# clean up
+rm -rf $TMP_HOME
+rm chain_output.log

--- a/scripts/testnet/config_example.sh
+++ b/scripts/testnet/config_example.sh
@@ -78,6 +78,13 @@ FAUCET=seda... # if set, creates a genesis account with 10x seda tokens compared
 CONTRACTS_VERSION=v0.0.1-rc # latest or seda-chain-contracts release version
 
 #######################################
+############ GROUP CONFIG #############
+#######################################
+MEMBERS_JSON_FILE=./members.json
+POLICY_JSON_FILE=./policy.json
+ADMIN_SEED="mushroom energy ..."
+
+#######################################
 ############### GITHUB ################
 #######################################
 GITHUB_TOKEN=ghp_... # github token for accessing seda-chain-contracts repo

--- a/scripts/testnet/members.json
+++ b/scripts/testnet/members.json
@@ -1,0 +1,14 @@
+{
+    "members": [
+        {
+            "address": "seda1g4tlruupkv9kp2n8fx5w70lscjkauy34vzutxs",
+            "weight": "1",
+            "metadata": "testnet_faucet"
+        },
+        {
+            "address": "seda1xd04svzj6zj93g4eknhp6aq2yyptagcc2zeetj",
+            "weight": "1",
+            "metadata": "testnet_gluax"
+        }
+    ]
+}

--- a/scripts/testnet/policy.json
+++ b/scripts/testnet/policy.json
@@ -1,0 +1,8 @@
+{
+    "@type": "/cosmos.group.v1.ThresholdDecisionPolicy",
+    "threshold": "1",
+    "windows": {
+        "voting_period": "2m",
+        "min_execution_period": "0s"
+    }
+}

--- a/scripts/testnet/upload_and_start.sh
+++ b/scripts/testnet/upload_and_start.sh
@@ -88,6 +88,7 @@ for i in ${!IPS[@]}; do
 	# upload chain binary built for the corresponding architecture
 	LINUX_BIN=$NODE_DIR/seda-chaind-amd64
 	ARCH=$(ssh -i $SSH_KEY -t ec2-user@${IPS[$i]} 'uname -m') # aarch64 or x86_64
+	ARCH=$(echo "$ARCH" | tr -d '\r')
 	if [ $ARCH == "aarch64" ]; then
 		LINUX_BIN=$NODE_DIR/seda-chaind-arm64
 	fi


### PR DESCRIPTION
## Motivation

This PR adds a script for adding a group and a group policy to the genesis state. 

## Explanation of Changes

To achieve this, the script deploys a temporary single-node chain and sends a `create-group-with-policy` transaction based on the configurations. Afterwards, the script terminates the chain, exports the state, and injects the group state into the original genesis file. Note that the script also adds the group policy address to the wasm module's genesis parameter as the only address that is allowed to store or instantiate code.

The deployment process is still a 3-step process:

1. `create_genesis.sh` for creating genesis file and other node files.
2. `build_genesis_state.sh`, which should be run with at least one of the flags `--add-wasm-contracts` and `--add-groups`.
3. `upload_and_start.sh` to upload the node files and binary and start a new chain.

The scripts use the configurations set in the file `config.sh`. See `config_example.sh` for instructions.

## Testing

Tested manually on local chain.


## Related PRs and Issues

Closes: #54 and #186

