### PR TITLE
Add Interchaintest in CI

### DIFF
--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -1,0 +1,94 @@
+name: Interchaintest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+env:
+  GO_VERSION: "1.21.0"
+  GOPRIVATE: github.com/sedaprotocol/vrf-go
+  GITHUB_TOKEN: ${{ secrets.PAT }}
+  TAR_PATH: /tmp/seda-docker-image.tar
+  IMAGE_NAME: seda-docker-image
+  SEDA_EXPONENT: 6
+
+permissions:
+  contents: read
+  repository-projects: read
+  packages: read
+
+concurrency:
+  group: ci-${{ github.ref }}-interchaintest
+  cancel-in-progress: true
+
+jobs:
+  build-docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: interchaintest/go.sum
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export
+        uses: docker/build-push-action@v5
+        with:
+          context: ./dockerfiles
+          file: Dockerfile.e2e
+          tags: seda:local
+          outputs: type=docker,dest=${{ env.TAR_PATH }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.IMAGE_NAME }}
+          path: ${{ env.TAR_PATH }}
+
+  interchaintest:
+    needs: build-docker-image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test:
+          - "ictest-sdk-commands"
+          - "ictest-sdk-boundaries"
+          - "ictest-chain-start"
+          - "ictest-conformance"
+          - "ictest-state-sync"
+          - "ictest-ibc-xfer"
+          - "ictest-packet-forward-middleware"
+      fail-fast: false
+
+    steps:
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: interchaintest/go.sum
+
+      - name: checkout chain
+        uses: actions/checkout@v4
+
+      - name: Download Tarball Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ env.IMAGE_NAME }}
+          path: /tmp
+
+      - name: Load Docker Image
+        run: |
+          docker image load -i ${{ env.TAR_PATH }}
+          docker image ls -a
+
+      - name: Run Test
+        run: make ${{ matrix.test }}

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -64,7 +64,6 @@ jobs:
           - "ictest-sdk-commands"
           - "ictest-sdk-boundaries"
           - "ictest-chain-start"
-          - "ictest-conformance"
           - "ictest-state-sync"
           - "ictest-ibc-xfer"
           - "ictest-packet-forward-middleware"

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: List dockerfiles directory
+        run: pwd && ls -la ./dockerfiles
+
       - name: Build and export
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -40,14 +40,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: List dockerfiles directory
-        run: pwd && ls -la ./dockerfiles
-
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
           context: ./dockerfiles
-          file: Dockerfile.e2e
+          file: dockerfiles/Dockerfile.e2e
           tags: seda:local
           outputs: type=docker,dest=${{ env.TAR_PATH }}
 

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -12,7 +12,7 @@ env:
   GOPRIVATE: github.com/sedaprotocol/vrf-go
   GITHUB_TOKEN: ${{ secrets.PAT }}
   TAR_PATH: /tmp/seda-docker-image.tar
-  IMAGE_NAME: seda-docker-image
+  IMAGE_NAME: sedaprotocol/seda-chaind-e2e
   SEDA_EXPONENT: 6
 
 permissions:

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -13,7 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
   TAR_PATH: /tmp/seda-docker-image.tar
   IMAGE_NAME: seda-chaind-e2e
-  SEDA_EXPONENT: 6
+  SEDA_EXPONENT: ${{ secrets.SEDA_EXPONENT_ICT || 18 }}
 
 permissions:
   contents: read

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/Dockerfile.e2e
-          tags: seda:local
+          tags: seda-chaind-e2e
           outputs: type=docker,dest=${{ env.TAR_PATH }}
 
       - name: Upload artifact

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -46,6 +46,7 @@ jobs:
           context: .
           file: ./dockerfiles/Dockerfile.e2e
           tags: seda-chaind-e2e
+          build-args: SEDA_EXPONENT=${{ env.SEDA_EXPONENT }}
           outputs: type=docker,dest=${{ env.TAR_PATH }}
 
       - name: Upload artifact

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -12,7 +12,7 @@ env:
   GOPRIVATE: github.com/sedaprotocol/vrf-go
   GITHUB_TOKEN: ${{ secrets.PAT }}
   TAR_PATH: /tmp/seda-docker-image.tar
-  IMAGE_NAME: sedaprotocol/seda-chaind-e2e
+  IMAGE_NAME: seda-chaind-e2e
   SEDA_EXPONENT: 6
 
 permissions:

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
-          context: ./dockerfiles
-          file: dockerfiles/Dockerfile.e2e
+          context: .
+          file: ./dockerfiles/Dockerfile.e2e
           tags: seda:local
           outputs: type=docker,dest=${{ env.TAR_PATH }}
 

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,33 @@ endif
 
 .PHONY: cover-html run-tests $(TEST_TARGETS) test test-race docker-build-e2e
 
+###############################################################################
+###                                interchaintest                           ###
+###############################################################################
+
+ictest-sdk-commands: rm-testcache
+	cd interchaintest && go test -race -v -run TestCoreSDKCommands .
+
+ictest-sdk-boundaries: rm-testcache
+	cd interchaintest && go test -race -v -run TestSDKBoundaries .
+
+ictest-chain-start: rm-testcache
+	cd interchaintest && go test -race -v -run TestChainStart .
+
+ictest-conformance: rm-testcache
+	cd interchaintest && go test -race -v -run TestConformance .
+
+ictest-state-sync: rm-testcache
+	cd interchaintest && go test -race -v -run TestStateSync .
+
+ictest-ibc-xfer: rm-testcache
+	cd interchaintest && go test -race -v -run TestIBCTransfer .
+
+ictest-packet-forward-middleware: rm-testcache
+	cd interchaintest && go test -race -v -run TestPacketForwardMiddleware .
+
+rm-testcache:
+	go clean -testcache
 
 ###############################################################################
 ###                                Release                                  ###

--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,6 @@ ictest-sdk-boundaries: rm-testcache
 ictest-chain-start: rm-testcache
 	cd interchaintest && go test -race -v -run TestChainStart .
 
-ictest-conformance: rm-testcache
-	cd interchaintest && go test -race -v -run TestConformance .
-
 ictest-state-sync: rm-testcache
 	cd interchaintest && go test -race -v -run TestStateSync .
 

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -38,7 +38,7 @@ var (
 func getSedaExponent() int64 {
 	sedaExponent := os.Getenv("SEDA_EXPONENT")
 	if sedaExponent == "" {
-		return 18 // default value
+		return 18 // default
 	}
 
 	value, err := strconv.Atoi(sedaExponent)

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -1,6 +1,9 @@
 package params
 
 import (
+	"os"
+	"strconv"
+
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
 
@@ -10,10 +13,8 @@ import (
 )
 
 const (
-	HumanCoinUnit = "seda"
-	BaseCoinUnit  = "aseda" // atto (10^-18)
-	SedaExponent  = 18
-
+	HumanCoinUnit    = "seda"
+	BaseCoinUnit     = "aseda" // atto (10^-18)
 	DefaultBondDenom = BaseCoinUnit
 
 	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address.
@@ -21,6 +22,7 @@ const (
 )
 
 var (
+	SedaExponent int64
 	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key.
 	Bech32PrefixAccPub = Bech32PrefixAccAddr + "pub"
 	// Bech32PrefixValAddr defines the Bech32 prefix of a validator's operator address.
@@ -33,7 +35,22 @@ var (
 	Bech32PrefixConsPub = Bech32PrefixAccAddr + "valconspub"
 )
 
+func getSedaExponent() int64 {
+	sedaExponent := os.Getenv("SEDA_EXPONENT")
+	if sedaExponent == "" {
+		return 18 // default value
+	}
+
+	value, err := strconv.Atoi(sedaExponent)
+	if err != nil {
+		panic(err)
+	}
+
+	return int64(value)
+}
+
 func init() {
+	SedaExponent = getSedaExponent()
 	SetAddressPrefixes()
 	RegisterDenoms()
 }

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -12,6 +12,9 @@ FROM golang:${GO_VERSION}-alpine as builder
 ARG GIT_VERSION
 ARG GIT_COMMIT
 ARG GITHUB_TOKEN
+ARG SEDA_EXPONENT
+
+ENV SEDA_EXPONENT=$SEDA_EXPONENT
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -2,6 +2,7 @@
 
 ARG GO_VERSION="1.21"
 ARG RUNNER_IMAGE="alpine:3.17"
+ARG SEDA_EXPONENT="18"
 
 # --------------------------------------------------------
 # Builder
@@ -64,11 +65,12 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 FROM ${RUNNER_IMAGE}
 
-ARG SEDA_EXPONENT
-
 COPY --from=builder /seda-chain/build/seda-chaind /bin/seda-chaind
 
+ARG SEDA_EXPONENT # use default if not set
+ENV SEDA_EXPONENT=${SEDA_EXPONENT}
 ENV HOME /seda-chain
+
 WORKDIR $HOME
 
 EXPOSE 26656 26657 1317 9090

--- a/dockerfiles/Dockerfile.e2e
+++ b/dockerfiles/Dockerfile.e2e
@@ -12,9 +12,6 @@ FROM golang:${GO_VERSION}-alpine as builder
 ARG GIT_VERSION
 ARG GIT_COMMIT
 ARG GITHUB_TOKEN
-ARG SEDA_EXPONENT
-
-ENV SEDA_EXPONENT=$SEDA_EXPONENT
 
 RUN apk add --no-cache \
     ca-certificates \
@@ -66,6 +63,8 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # --------------------------------------------------------
 
 FROM ${RUNNER_IMAGE}
+
+ARG SEDA_EXPONENT
 
 COPY --from=builder /seda-chain/build/seda-chaind /bin/seda-chaind
 

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -22,7 +22,7 @@ const (
 	upgradeName        = "v1"
 	initialVersion     = "old"
 	upgradeVersion     = "new"
-	upgradeRepo        = "sedaprotocol/seda-chaind-e2e"
+	upgradeRepo        = "seda-chaind-e2e"
 	haltHeightDelta    = uint64(10) // # of blocks after which to submit upgrade proposal
 	blocksAfterUpgrade = uint64(10) // # of blocks to wait after upgrade is applied
 )
@@ -32,7 +32,7 @@ var (
 
 	// current chain version we are upgrading from
 	baseChain = ibc.DockerImage{
-		Repository: "sedaprotocol/seda-chaind-e2e", // to be replaced by sedaRepo once we have Docker images setup
+		Repository: "seda-chaind-e2e", // to be replaced by sedaRepo once we have Docker images setup
 		Version:    initialVersion,
 		UidGid:     "1025:1025",
 	}

--- a/interchaintest/ibc_transfer_test.go
+++ b/interchaintest/ibc_transfer_test.go
@@ -133,11 +133,11 @@ func runIBCTransferTest(t *testing.T, counterpartyChainSpec *interchaintest.Chai
 	// Get original account balances
 	sedaOrigBal, err := sedaChain.GetBalance(ctx, sedaUserAddr, sedaChain.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, GenesisWalletAmount, sedaOrigBal.Int64())
+	require.Equal(t, GenesisWalletAmount, sedaOrigBal)
 
 	gaiaOrigBal, err := counterpartyChain.GetBalance(ctx, gaiaUserAddr, counterpartyChain.Config().Denom)
 	require.NoError(t, err)
-	require.Equal(t, GenesisWalletAmount, gaiaOrigBal.Int64())
+	require.Equal(t, GenesisWalletAmount, gaiaOrigBal)
 
 	/* =================================================== */
 	/*                  INTERCHAIN TEST                    */

--- a/interchaintest/ibc_transfer_test.go
+++ b/interchaintest/ibc_transfer_test.go
@@ -17,9 +17,9 @@ import (
 	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 )
 
-// TestSedaGaiaIBCTransfer spins up a Seda and Gaia network, initializes an IBC connection between them,
+// TestIBCTransfer spins up a Seda and Gaia network, initializes an IBC connection between them,
 // and sends an ICS20 token transfer from Seda->Gaia and then back from Gaia->Seda.
-func TestSedaGaiaIBCTransfer(t *testing.T) {
+func TestIBCTransfer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -30,8 +30,8 @@ var (
 	SedaChainName = "seda"
 
 	dockerImage = ibc.DockerImage{
-		Repository: "sedaprotocol/seda-chaind-e2e", // FOR LOCAL IMAGE USE: Docker Image Name
-		Version:    "latest",                       // FOR LOCAL IMAGE USE: Docker Image Tag
+		Repository: "seda-chaind-e2e", // FOR LOCAL IMAGE USE: Docker Image Name
+		Version:    "latest",          // FOR LOCAL IMAGE USE: Docker Image Tag
 		UidGid:     "1025:1025",
 	}
 


### PR DESCRIPTION
## Overview
This PR adds the following e2e tests in CI:
- `TestCoreSDKCommands`
- `TestSDKBoundaries`
- `TestChainStart`
- `TestStateSync`
- `TestIBCTransfer`
- `TestPacketForwardMiddleware`

## Key Points
- Due to interchaintest v8 only supporting denom exponent of 6, to make the tests work we needed to change `SedaExponent` to 6 (default 18) at runtime via an environment variable. This only applies when an `SedaExponent` env var is provided (e.g. when running interchaintest). Otherwise, it simply default to 18
- `TestPacketForwardMiddleware` can be flaky and fail sometimes. If and when that happens, simply re-run it

## References
![image](https://github.com/sedaprotocol/seda-chain/assets/31609693/d30fa1de-d6fe-48f8-a8a1-02d63032a7f1)