### PR TITLE
test: Add simulation test

### DIFF
--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -1,0 +1,47 @@
+name: Simulation
+#  Simulation workflow runs simulation test
+#  This workflow is run on pushes to master & every Pull Requests where a .go, .mod, .sum have been changed
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  GO_VERSION: "1.21.0"
+  
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache: true
+          cache-dependency-path: go.sum
+      -
+        name: Get git diff
+        uses: technote-space/get-diff-action@v6.1.2
+        with:
+          PATTERNS: |
+            **/**!(test).go
+            go.mod
+            go.sum
+            Makefile
+
+      - name: Run determinism check simulation
+        run: |
+          make test-sim-determinism
+        if: env.GIT_DIFF
+
+      - name: Run export-import simulation
+        run: |
+          make test-sim-export-import
+        if: env.GIT_DIFF
+
+      - name: Run after-import simulation
+        run: |
+          make test-sim-after-import
+        if: env.GIT_DIFF

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,40 @@ endif
 .PHONY: cover-html run-tests $(TEST_TARGETS) test test-race docker-build-e2e
 
 ###############################################################################
+###                             Simulation Tests                            ###
+###############################################################################
+
+CURRENT_DIR = $(shell pwd)
+
+test-sim-determinism:
+	@echo "Running determinism test..."
+	@cd ${CURRENT_DIR}/simulation && go test -mod=readonly -run TestAppStateDeterminism -Enabled=true \
+		-NumBlocks=100 -BlockSize=200 -Commit=true -Period=0 -v -timeout 24h
+
+test-sim-export-import:
+	@echo "Running export-import test..."
+	@cd ${CURRENT_DIR}/simulation && go test -mod=readonly -run TestAppExportImport -Enabled=true \
+		-NumBlocks=100 -BlockSize=200 -Commit=true -Period=0 -v -timeout 24h
+
+test-sim-after-import:
+	@echo "Running simulation-after-import test..."
+	@cd ${CURRENT_DIR}/simulation && go test -mod=readonly -run TestAppSimulationAfterImport -Enabled=true \
+		-NumBlocks=100 -BlockSize=200 -Commit=true -Period=0 -v -timeout 24h
+
+.PHONY: test-sim-determinism test-sim-export-import test-sim-after-import
+
+SIM_NUM_BLOCKS ?= 500
+SIM_BLOCK_SIZE ?= 200
+SIM_COMMIT ?= true
+
+test-sim-benchmark:
+	@echo "Running application benchmark for numBlocks=$(SIM_NUM_BLOCKS), blockSize=$(SIM_BLOCK_SIZE). This may take awhile!"
+	@cd ${CURRENT_DIR}/simulation && go test -mod=readonly -run=^$$ $(.) -bench ^BenchmarkSimulation$$  \
+		-Enabled=true -NumBlocks=$(SIM_NUM_BLOCKS) -BlockSize=$(SIM_BLOCK_SIZE) -Commit=$(SIM_COMMIT) -timeout 24h
+
+.PHONY: test-sim-benchmark
+
+###############################################################################
 ###                                interchaintest                           ###
 ###############################################################################
 

--- a/app/app.go
+++ b/app/app.go
@@ -567,18 +567,6 @@ func NewApp(
 		wasmOpts...,
 	)
 
-	// //
-	// //
-	// // Register the proposal types
-	// // Deprecated: Avoid adding new handlers, instead use the new proposal flow
-	// // by granting the governance module the right to execute the message.
-	// // See: https://docs.cosmos.network/main/modules/gov#proposal-messages
-	// govRouter := govv1beta1.NewRouter()
-	// govRouter.AddRoute(govtypes.RouterKey, govv1beta1.ProposalHandler).
-	// 	AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper))
-	// //
-	// //
-
 	govConfig := govtypes.DefaultConfig()
 	govKeeper := govkeeper.NewKeeper(
 		appCodec,
@@ -591,13 +579,6 @@ func NewApp(
 		govConfig,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
-
-	// //
-	// //
-	// // Set legacy router for backwards compatibility with gov v1beta1
-	// govKeeper.SetLegacyRouter(govRouter)
-	// //
-	// //
 
 	app.GovKeeper = *govKeeper.SetHooks(
 		govtypes.NewMultiGovHooks(

--- a/app/genesis.go
+++ b/app/genesis.go
@@ -1,9 +1,16 @@
 package app
 
 import (
+	"crypto/rand"
 	"encoding/json"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/types/simulation"
+	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 )
 
 // The genesis state of the blockchain is represented here as a map of raw json
@@ -18,4 +25,50 @@ type GenesisState map[string]json.RawMessage
 // NewDefaultGenesisState generates the default state for the application.
 func NewDefaultGenesisState(cdc codec.JSONCodec) GenesisState {
 	return ModuleBasics.DefaultGenesis(cdc)
+}
+
+// randomGenesisAccounts defines the default RandomGenesisAccountsFn used on the SDK.
+// It creates a slice of BaseAccount, ContinuousVestingAccount and DelayedVestingAccount.
+// NOTE: This function is a modified version of
+// https://github.com/cosmos/cosmos-sdk/blob/7e6948f50cd4838a0161838a099f74e0b5b0213c/x/auth/simulation/genesis.go#L26
+func randomGenesisAccounts(simState *module.SimulationState) types.GenesisAccounts {
+	genesisAccs := make(types.GenesisAccounts, len(simState.Accounts))
+	for i, acc := range simState.Accounts {
+		bacc := types.NewBaseAccountWithAddress(acc.Address)
+
+		// Only consider making a vesting account once the initial bonded validator
+		// set is exhausted due to needing to track DelegatedVesting.
+		if !(int64(i) > simState.NumBonded && simState.Rand.Intn(100) < 50) {
+			genesisAccs[i] = bacc
+			continue
+		}
+
+		initialVestingAmount, err := rand.Int(rand.Reader, simState.InitialStake.BigInt())
+		if err != nil {
+			panic(err)
+		}
+		initialVesting := sdk.NewCoins(sdk.NewCoin(simState.BondDenom, sdkmath.NewIntFromBigInt(initialVestingAmount)))
+
+		var endTime int64
+		startTime := simState.GenTimestamp.Unix()
+		// Allow for some vesting accounts to vest very quickly while others very slowly.
+		if simState.Rand.Intn(100) < 50 {
+			endTime = int64(simulation.RandIntBetween(simState.Rand, int(startTime)+1, int(startTime+(60*60*24*30))))
+		} else {
+			endTime = int64(simulation.RandIntBetween(simState.Rand, int(startTime)+1, int(startTime+(60*60*12))))
+		}
+
+		bva, err := vestingtypes.NewBaseVestingAccount(bacc, initialVesting, endTime)
+		if err != nil {
+			panic(err)
+		}
+
+		if simState.Rand.Intn(100) < 50 {
+			genesisAccs[i] = vestingtypes.NewContinuousVestingAccountRaw(bva, startTime)
+		} else {
+			genesisAccs[i] = vestingtypes.NewDelayedVestingAccountRaw(bva)
+		}
+	}
+
+	return genesisAccs
 }

--- a/simulation/helpers_test.go
+++ b/simulation/helpers_test.go
@@ -1,0 +1,260 @@
+package app_test
+
+import (
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"os"
+	"time"
+
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+type storeKeysPrefixes struct {
+	A        storetypes.StoreKey
+	B        storetypes.StoreKey
+	Prefixes [][]byte
+}
+
+// fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
+// an IAVLStore for faster simulation speed.
+func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
+	bapp.SetFauxMerkleMode()
+}
+
+// simulationOperations retrieves the simulation params from the provided file path
+// and returns all the modules weighted operations
+func simulationOperations(app runtime.AppI, cdc codec.JSONCodec, config simtypes.Config) []simtypes.WeightedOperation {
+	simState := module.SimulationState{
+		AppParams: make(simtypes.AppParams),
+		Cdc:       cdc,
+		TxConfig:  moduletestutil.MakeTestTxConfig(),
+		BondDenom: sdk.DefaultBondDenom,
+	}
+
+	if config.ParamsFile != "" {
+		bz, err := os.ReadFile(config.ParamsFile)
+		if err != nil {
+			panic(err)
+		}
+
+		err = json.Unmarshal(bz, &simState.AppParams)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	simState.LegacyProposalContents = nil
+	simState.ProposalMsgs = app.SimulationManager().GetProposalMsgs(simState)
+	return app.SimulationManager().WeightedOperations(simState)
+}
+
+// Simulation parameter constants
+const (
+	StakePerAccount           = "stake_per_account"
+	InitiallyBondedValidators = "initially_bonded_validators"
+)
+
+// appStateFn returns the initial application state using a genesis or the simulation parameters.
+// NOTE: This function is a modified version of
+// github.com/cosmos/cosmos-sdk/blob/7e6948f50cd4838a0161838a099f74e0b5b0213c/testutil/sims/state_helpers.go#L56
+func appStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager, genesisState map[string]json.RawMessage) simtypes.AppStateFn {
+	return func(
+		r *rand.Rand,
+		accs []simtypes.Account,
+		config simtypes.Config,
+	) (appState json.RawMessage, simAccs []simtypes.Account, chainID string, genesisTimestamp time.Time) {
+		if simcli.FlagGenesisTimeValue == 0 {
+			genesisTimestamp = simtypes.RandTimestamp(r)
+		} else {
+			genesisTimestamp = time.Unix(simcli.FlagGenesisTimeValue, 0)
+		}
+
+		chainID = config.ChainID
+		switch {
+		case config.ParamsFile != "" && config.GenesisFile != "":
+			panic("cannot provide both a genesis file and a params file")
+
+		case config.GenesisFile != "":
+			// override the default chain-id from simapp to set it later to the config
+			genesisDoc, accounts, err := simtestutil.AppStateFromGenesisFileFn(r, cdc, config.GenesisFile)
+			if err != nil {
+				panic(err)
+			}
+
+			if simcli.FlagGenesisTimeValue == 0 {
+				// use genesis timestamp if no custom timestamp is provided (i.e no random timestamp)
+				genesisTimestamp = genesisDoc.GenesisTime
+			}
+
+			appState = genesisDoc.AppState
+			chainID = genesisDoc.ChainID
+			simAccs = accounts
+
+		case config.ParamsFile != "":
+			appParams := make(simtypes.AppParams)
+			bz, err := os.ReadFile(config.ParamsFile)
+			if err != nil {
+				panic(err)
+			}
+
+			err = json.Unmarshal(bz, &appParams)
+			if err != nil {
+				panic(err)
+			}
+			appState, simAccs = appStateRandomizedFn(simManager, r, cdc, accs, genesisTimestamp, appParams, genesisState)
+
+		default:
+			appParams := make(simtypes.AppParams)
+			appState, simAccs = appStateRandomizedFn(simManager, r, cdc, accs, genesisTimestamp, appParams, genesisState)
+		}
+
+		rawState := make(map[string]json.RawMessage)
+		err := json.Unmarshal(appState, &rawState)
+		if err != nil {
+			panic(err)
+		}
+
+		stakingStateBz, ok := rawState[stakingtypes.ModuleName]
+		if !ok {
+			panic("staking genesis state is missing")
+		}
+
+		stakingState := new(stakingtypes.GenesisState)
+		if err = cdc.UnmarshalJSON(stakingStateBz, stakingState); err != nil {
+			panic(err)
+		}
+		// compute not bonded balance
+		notBondedTokens := math.ZeroInt()
+		for _, val := range stakingState.Validators {
+			if val.Status != stakingtypes.Unbonded {
+				continue
+			}
+			notBondedTokens = notBondedTokens.Add(val.GetTokens())
+		}
+		notBondedCoins := sdk.NewCoin(stakingState.Params.BondDenom, notBondedTokens)
+		// edit bank state to make it have the not bonded pool tokens
+		bankStateBz, ok := rawState[banktypes.ModuleName]
+		// TODO(fdymylja/jonathan): should we panic in this case
+		if !ok {
+			panic("bank genesis state is missing")
+		}
+		bankState := new(banktypes.GenesisState)
+		if err = cdc.UnmarshalJSON(bankStateBz, bankState); err != nil {
+			panic(err)
+		}
+
+		stakingAddr := authtypes.NewModuleAddress(stakingtypes.NotBondedPoolName).String()
+		var found bool
+		for _, balance := range bankState.Balances {
+			if balance.Address == stakingAddr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			bankState.Balances = append(bankState.Balances, banktypes.Balance{
+				Address: stakingAddr,
+				Coins:   sdk.NewCoins(notBondedCoins),
+			})
+		}
+
+		// change appState back
+		rawState[stakingtypes.ModuleName] = cdc.MustMarshalJSON(stakingState)
+		rawState[banktypes.ModuleName] = cdc.MustMarshalJSON(bankState)
+
+		// replace appstate
+		appState, err = json.Marshal(rawState)
+		if err != nil {
+			panic(err)
+		}
+		return appState, simAccs, chainID, genesisTimestamp
+	}
+}
+
+// appStateRandomizedFn creates calls each module's GenesisState generator function
+// and creates the simulation params
+func appStateRandomizedFn(
+	simManager *module.SimulationManager,
+	r *rand.Rand,
+	cdc codec.JSONCodec,
+	accs []simtypes.Account,
+	genesisTimestamp time.Time,
+	appParams simtypes.AppParams,
+	genesisState map[string]json.RawMessage,
+) (json.RawMessage, []simtypes.Account) {
+	numAccs := int64(len(accs))
+	// generate a random amount of initial stake coins and a random initial
+	// number of bonded accounts
+	var (
+		numInitiallyBonded int64
+		initialStake       math.Int
+	)
+
+	// max value 10^24 aseda
+	max := big.NewInt(0).Exp(big.NewInt(10), big.NewInt(24), nil)
+	initialStakeAmount, err := cryptorand.Int(cryptorand.Reader, max)
+	if err != nil {
+		panic(err)
+	}
+
+	appParams.GetOrGenerate(
+		StakePerAccount, &initialStake, r,
+		func(r *rand.Rand) {
+			initialStake = math.NewIntFromBigInt(initialStakeAmount)
+		},
+	)
+	appParams.GetOrGenerate(
+		InitiallyBondedValidators, &numInitiallyBonded, r,
+		func(r *rand.Rand) { numInitiallyBonded = int64(r.Intn(300)) },
+	)
+
+	if numInitiallyBonded > numAccs {
+		numInitiallyBonded = numAccs
+	}
+
+	fmt.Printf(
+		`Selected randomly generated parameters for simulated genesis:
+{
+  stake_per_account: "%s",
+  initially_bonded_validators: "%d"
+}
+`, initialStake.String(), numInitiallyBonded,
+	)
+
+	simState := &module.SimulationState{
+		AppParams:    appParams,
+		Cdc:          cdc,
+		Rand:         r,
+		GenState:     genesisState,
+		Accounts:     accs,
+		InitialStake: initialStake,
+		NumBonded:    numInitiallyBonded,
+		BondDenom:    sdk.DefaultBondDenom,
+		GenTimestamp: genesisTimestamp,
+	}
+
+	simManager.GenerateGenesisStates(simState)
+
+	appState, err := json.Marshal(genesisState)
+	if err != nil {
+		panic(err)
+	}
+
+	return appState, accs
+}

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"cosmossdk.io/log"
-	storetypes "cosmossdk.io/store/types"
 	evidencetypes "cosmossdk.io/x/evidence/types"
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +28,6 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
-	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 	simcli "github.com/cosmos/cosmos-sdk/x/simulation/client/cli"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -39,21 +37,9 @@ import (
 	"github.com/sedaprotocol/seda-chain/app"
 )
 
-type storeKeysPrefixes struct {
-	A        storetypes.StoreKey
-	B        storetypes.StoreKey
-	Prefixes [][]byte
-}
-
 // Get flags every time the simulator is run
 func init() {
 	simcli.GetSimulatorFlags()
-}
-
-// fauxMerkleModeOpt returns a BaseApp option to use a dbStoreAdapter instead of
-// an IAVLStore for faster simulation speed.
-func fauxMerkleModeOpt(bapp *baseapp.BaseApp) {
-	bapp.SetFauxMerkleMode()
 }
 
 // BenchmarkSimulation run the chain simulation
@@ -105,13 +91,13 @@ func BenchmarkSimulation(b *testing.B) {
 		b,
 		os.Stdout,
 		bApp.BaseApp,
-		simtestutil.AppStateFn(
+		appStateFn(
 			bApp.AppCodec(),
 			bApp.SimulationManager(),
 			app.NewDefaultGenesisState(bApp.AppCodec()),
 		),
 		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
+		simulationOperations(bApp, bApp.AppCodec(), config),
 		bApp.ModuleAccountAddrs(),
 		config,
 		bApp.AppCodec(),
@@ -184,13 +170,13 @@ func TestAppStateDeterminism(t *testing.T) {
 				t,
 				os.Stdout,
 				bApp.BaseApp,
-				simtestutil.AppStateFn(
+				appStateFn(
 					bApp.AppCodec(),
 					bApp.SimulationManager(),
 					app.NewDefaultGenesisState(bApp.AppCodec()),
 				),
 				simulationtypes.RandomAccounts,
-				simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
+				simulationOperations(bApp, bApp.AppCodec(), config),
 				bApp.ModuleAccountAddrs(),
 				config,
 				bApp.AppCodec(),
@@ -257,13 +243,13 @@ func TestAppImportExport(t *testing.T) {
 		t,
 		os.Stdout,
 		bApp.BaseApp,
-		simtestutil.AppStateFn(
+		appStateFn(
 			bApp.AppCodec(),
 			bApp.SimulationManager(),
 			app.NewDefaultGenesisState(bApp.AppCodec()),
 		),
 		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
+		simulationOperations(bApp, bApp.AppCodec(), config),
 		bApp.BlockedModuleAccountAddrs(),
 		config,
 		bApp.AppCodec(),
@@ -349,7 +335,6 @@ func TestAppImportExport(t *testing.T) {
 		{bApp.GetKey(minttypes.StoreKey), newApp.GetKey(minttypes.StoreKey), [][]byte{}},
 		{bApp.GetKey(distrtypes.StoreKey), newApp.GetKey(distrtypes.StoreKey), [][]byte{}},
 		{bApp.GetKey(banktypes.StoreKey), newApp.GetKey(banktypes.StoreKey), [][]byte{banktypes.BalancesPrefix}},
-		{bApp.GetKey(paramstypes.StoreKey), newApp.GetKey(paramstypes.StoreKey), [][]byte{}},
 		{bApp.GetKey(govtypes.StoreKey), newApp.GetKey(govtypes.StoreKey), [][]byte{}},
 		{bApp.GetKey(evidencetypes.StoreKey), newApp.GetKey(evidencetypes.StoreKey), [][]byte{}},
 		{bApp.GetKey(capabilitytypes.StoreKey), newApp.GetKey(capabilitytypes.StoreKey), [][]byte{}},
@@ -412,13 +397,13 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		t,
 		os.Stdout,
 		bApp.BaseApp,
-		simtestutil.AppStateFn(
+		appStateFn(
 			bApp.AppCodec(),
 			bApp.SimulationManager(),
 			app.NewDefaultGenesisState(bApp.AppCodec()),
 		),
 		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(bApp, bApp.AppCodec(), config),
+		simulationOperations(bApp, bApp.AppCodec(), config),
 		bApp.BlockedModuleAccountAddrs(),
 		config,
 		bApp.AppCodec(),
@@ -483,13 +468,13 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		t,
 		os.Stdout,
 		newApp.BaseApp,
-		simtestutil.AppStateFn(
+		appStateFn(
 			bApp.AppCodec(),
 			bApp.SimulationManager(),
 			app.NewDefaultGenesisState(bApp.AppCodec()),
 		),
 		simulationtypes.RandomAccounts,
-		simtestutil.SimulationOperations(newApp, newApp.AppCodec(), config),
+		simulationOperations(newApp, newApp.AppCodec(), config),
 		newApp.BlockedModuleAccountAddrs(),
 		config,
 		bApp.AppCodec(),

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -43,10 +43,8 @@ func init() {
 }
 
 // BenchmarkSimulation run the chain simulation
-// Running using starport command:
-// `starport chain simulate -v --numBlocks 200 --blockSize 50`
 // Running as go benchmark test:
-// `go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./app -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true`
+// go test -benchmem -run=^$ -bench ^BenchmarkSimulation ./simulation -NumBlocks=200 -BlockSize 50 -Commit=true -Verbose=true -Enabled=true
 func BenchmarkSimulation(b *testing.B) {
 	simcli.FlagSeedValue = time.Now().Unix()
 	simcli.FlagVerboseValue = true
@@ -162,7 +160,7 @@ func TestAppStateDeterminism(t *testing.T) {
 			)
 
 			fmt.Printf(
-				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
+				"running determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",
 				config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
 			)
 
@@ -193,16 +191,16 @@ func TestAppStateDeterminism(t *testing.T) {
 			if j != 0 {
 				require.Equal(
 					t, string(appHashList[0]), string(appHashList[j]),
-					"non-determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
+					"determinism in seed %d: %d/%d, attempt: %d/%d\n", config.Seed, i+1, numSeeds, j+1, numTimesToRunPerSeed,
 				)
 			}
 		}
 	}
 }
 
-func TestAppImportExport(t *testing.T) {
+func TestAppExportImport(t *testing.T) {
 	config := simcli.NewConfigFromFlags()
-	config.ChainID = "seda-simapp-import"
+	config.ChainID = "seda-simapp-export-import"
 
 	db, dir, logger, skip, err := simtestutil.SetupSimulation(
 		config,


### PR DESCRIPTION
## Motivation

Add SDK's simulation testing that sends fuzzed transactions to the chain and tests import, export, determinism, etc.

Even though this PR only adds simulation testing for the SDK module, some customization is required mainly due to our unique aseda denom (high exponent) and our lack of support for legacy gov proposal. 

## Explanation of Changes



Closes: #63