### PR TITLE
Cancel simulation workflows when an update is pushed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,11 +2,10 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    push:
+      branches:
+        - main
 
 env:
   GO_VERSION: "1.21.0"

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -1,11 +1,10 @@
 name: Interchaintest
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    push:
+      branches:
+        - main
 
 env:
   GO_VERSION: "1.21.0"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,9 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
-  push:
-    tags:
-      - v*
-    branches:
-      - main
+    push:
+      branches:
+        - main
 
 permissions:
   contents: read

--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -3,9 +3,9 @@ name: Simulation
 #  This workflow is run on pushes to master & every Pull Requests where a .go, .mod, .sum have been changed
 on:
   pull_request:
-  push:
-    branches:
-      - main
+    push:
+      branches:
+        - main
 
 env:
   GO_VERSION: "1.21.0"

--- a/.github/workflows/simulations.yml
+++ b/.github/workflows/simulations.yml
@@ -9,6 +9,10 @@ on:
 
 env:
   GO_VERSION: "1.21.0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
   
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,10 @@
 name: Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    push:
+      branches:
+        - main
 
 env:
   GO_VERSION: "1.21.0"


### PR DESCRIPTION
## Motivation

This saves some compute when frequently updating PRs.

## Explanation of Changes

I used the same concurrency key that most other workflows are using.

## Testing

Did not test, but since this works for other workflows I'm fairly confident it will work. Famous last words...

## Related PRs and Issues

See the GHA runs for #214, `simulation` was not cancelled while `test` and `interchaintest` were when updates were pushed in quick succession.