### PR TITLE
chore: cleanup TODO comments

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -25,8 +25,6 @@ We use clang format to format our protobuf generated code.
   - Using [brew](https://brew.sh/): `brew install clang-format`
   - Using [macports](https://www.macports.org/): `sudo port install clang-format`
 
-# TODO don't rely on docker for this
-
 ### [docker](https://www.docker.com/)
 
 Docker is used to help make release and static builds locally.

--- a/app/app.go
+++ b/app/app.go
@@ -625,7 +625,6 @@ func NewApp(
 		packetforwardkeeper.DefaultRefundTransferPacketTimeoutTimestamp,  // refund timeout
 	)
 	transferStack = ibcfee.NewIBCMiddleware(transferStack, app.IBCFeeKeeper)
-	// TO-DO consider adding ibc hooks
 
 	/* =================================================== */
 	/*                    ICA STACK                        */
@@ -686,7 +685,6 @@ func NewApp(
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 
-	// TO-DO double check the modules
 	app.mm = module.NewManager(
 		genutil.NewAppModule(app.AccountKeeper, app.StakingKeeper, app, txConfig),
 		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, nil),

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -86,7 +86,6 @@ func SetAddressPrefixes() {
 			return errorsmod.Wrapf(sdkerrors.ErrUnknownAddress, "address max length is %d, got %d, %x", address.MaxAddrLen, len(bytes), bytes)
 		}
 
-		// TODO: Do we want to allow addresses of lengths other than 20 and 32 bytes?
 		if len(bytes) != 20 && len(bytes) != 32 {
 			return errorsmod.Wrapf(sdkerrors.ErrUnknownAddress, "address length must be 20 or 32 bytes, got %d, %x", len(bytes), bytes)
 		}

--- a/cmd/sedad/cmd/init_cmds.go
+++ b/cmd/sedad/cmd/init_cmds.go
@@ -65,20 +65,18 @@ $ %s join moniker --network devnet
 				return fmt.Errorf("unsupported network type: %s", network)
 			}
 
-			// TO-DO remove (See: https://github.com/sedaprotocol/seda-chain/pull/76#issuecomment-1762303200)
 			// If validator key file exists, create and save an empty validator state file.
 			err = configureValidatorFiles(config)
 			if err != nil {
 				return err
 			}
 
-			// initialize the node
+			// Initialize the node.
 			nodeID, _, err := genutil.InitializeNodeValidatorFilesFromMnemonic(config, mnemonic)
 			if err != nil {
 				return err
 			}
 
-			// genesis and config files already written - display info
 			toPrint := utils.NewPrintInfo(config.Moniker, chainID, nodeID, seeds)
 			return utils.DisplayInfo(toPrint)
 		},

--- a/cmd/sedad/cmd/root.go
+++ b/cmd/sedad/cmd/root.go
@@ -61,9 +61,9 @@ func NewRootCmd() *cobra.Command {
 	cfg.SetAddressVerifier(wasmtypes.VerifyAddressLen())
 	cfg.Seal()
 
-	// TO-DO depinject
-	// we "pre"-instantiate the application for getting the injected/configured encoding configuration
-	// note, this is not necessary when using app wiring, as depinject can be directly used (see root_v2.go)
+	// "Pre-instantiate" the application for getting the injected/configured
+	// encoding configuration note, this is not necessary when using app wiring,
+	// as depinject can be directly used (see root_v2.go)
 	tempApp := app.NewApp(
 		log.NewNopLogger(),
 		dbm.NewMemDB(),
@@ -144,7 +144,6 @@ func NewRootCmd() *cobra.Command {
 
 	initRootCmd(rootCmd, encodingConfig, tempApp.BasicModuleManager())
 
-	// TO-DO unnecessary once depinject is implemented
 	autoCliOpts := tempApp.AutoCliOpts()
 	initClientCtx, _ = config.ReadFromClientConfig(initClientCtx)
 	autoCliOpts.Keyring, _ = keyring.NewAutoCLIKeyring(initClientCtx.Keyring)

--- a/e2e/e2e_gov_test.go
+++ b/e2e/e2e_gov_test.go
@@ -204,7 +204,7 @@ func (s *IntegrationTestSuite) validateGetSeedResponse(expectEmpty bool) func([]
 		if expectEmpty {
 			s.Require().Empty(getSeedResponse.Data.Seed)
 		} else {
-			s.Require().NotEmpty(getSeedResponse.Data.Seed) // TO-DO better seed check
+			s.Require().NotEmpty(getSeedResponse.Data.Seed)
 		}
 		return true
 	}

--- a/plugins/indexing/bank/module.go
+++ b/plugins/indexing/bank/module.go
@@ -62,6 +62,6 @@ func ExtractUpdate(_ codec.Codec, change *storetypes.StoreKVPair) (*types.Messag
 		return types.NewMessage("account-balance", data), nil
 	}
 
-	// TODO Log warning ("unable to process change %v", change)
+	// TODO(#217) Log warning ("unable to process change %v", change)
 	return nil, nil
 }

--- a/scripts/testnet/create_genesis.sh
+++ b/scripts/testnet/create_genesis.sh
@@ -64,7 +64,6 @@ cat $HOME/.sedad/config/genesis.json | jq '.app_state["slashing"]["params"]["sla
 # consensus params
 cat $HOME/.sedad/config/genesis.json | jq '.consensus["params"]["block"]["max_gas"]="100000000"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
 
-# TO-DO wasm params
 
 #
 #   ADD GENESIS ACCOUNTS

--- a/simulation/helpers_test.go
+++ b/simulation/helpers_test.go
@@ -150,7 +150,6 @@ func appStateFn(cdc codec.JSONCodec, simManager *module.SimulationManager, genes
 		notBondedCoins := sdk.NewCoin(stakingState.Params.BondDenom, notBondedTokens)
 		// edit bank state to make it have the not bonded pool tokens
 		bankStateBz, ok := rawState[banktypes.ModuleName]
-		// TODO(fdymylja/jonathan): should we panic in this case
 		if !ok {
 			panic("bank genesis state is missing")
 		}

--- a/x/randomness/keeper/abci.go
+++ b/x/randomness/keeper/abci.go
@@ -230,7 +230,7 @@ func generateAndSignNewSeedTx(ctx sdk.Context, txConfig client.TxConfig, vrfSign
 	if err != nil {
 		return nil, nil, err
 	}
-	txBuilder.SetGasLimit(200000) // TO-DO what number to put here?
+	txBuilder.SetGasLimit(200000)
 	txBuilder.SetFeeAmount(sdk.NewCoins())
 	txBuilder.SetFeePayer(account.GetAddress())
 

--- a/x/randomness/keeper/msg_server.go
+++ b/x/randomness/keeper/msg_server.go
@@ -23,8 +23,5 @@ var _ types.MsgServer = msgServer{}
 func (k msgServer) NewSeed(goCtx context.Context, msg *types.MsgNewSeed) (*types.MsgNewSeedResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(goCtx)
 	k.Keeper.SetSeed(sdkCtx, msg.Beta)
-
-	// TO-DO event?
-
 	return &types.MsgNewSeedResponse{}, nil
 }

--- a/x/staking/keeper/keeper.go
+++ b/x/staking/keeper/keeper.go
@@ -103,7 +103,7 @@ func (k Keeper) TransferDelegation(ctx context.Context, fromAddr, toAddr sdk.Acc
 	// Update or create the delTo object, calling appropriate hooks
 	delTo, err := k.GetDelegation(ctx, toAddr, valAddr)
 	if err != nil {
-		if err == types.ErrNoDelegation { // TO-DO
+		if err == types.ErrNoDelegation {
 			delTo = types.NewDelegation(toAddr.String(), validator.GetOperator(), math.LegacyZeroDec())
 			err = k.Hooks().BeforeDelegationCreated(ctx, toAddr, valAddr)
 		} else {
@@ -286,7 +286,6 @@ func (k Keeper) TransferUnbonding(ctx context.Context, fromAddr, toAddr sdk.AccA
 			return transferred, err
 		}
 		if maxed {
-			// TODO pre-compute the maximum entries we can add rather than checking each time
 			break
 		}
 		ubdTo, err := k.SetUnbondingDelegationEntry(ctx, toAddr, valAddr, entry.CreationHeight, entry.CompletionTime, toXfer)

--- a/x/staking/module.go
+++ b/x/staking/module.go
@@ -57,7 +57,7 @@ func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 
 // RegisterInterfaces registers the module's interface types
 func (AppModuleBasic) RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
-	// TO-DO to be activated later
+	// TODO(#208) to be activated later
 	// types.RegisterInterfaces(registry)
 	// err := registry.EnsureRegistered(&types.MsgCreateValidatorWithVRF{})
 	// if err != nil {
@@ -92,7 +92,7 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *g
 
 // GetTxCmd returns the root tx command for the staking module.
 func (amb AppModuleBasic) GetTxCmd() *cobra.Command {
-	// TO-DO to be activated later
+	// TODO(#208) to be activated later
 	// return cli.NewTxCmd(amb.cdc.InterfaceRegistry().SigningContext().ValidatorAddressCodec(), amb.cdc.InterfaceRegistry().SigningContext().AddressCodec())
 
 	return sdkcli.NewTxCmd(amb.cdc.InterfaceRegistry().SigningContext().ValidatorAddressCodec(), amb.cdc.InterfaceRegistry().SigningContext().AddressCodec())
@@ -134,7 +134,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	sdkMsgServer := NewMsgServerImpl(am.keeper.Keeper, am.accountKeeper)
 	sdktypes.RegisterMsgServer(cfg.MsgServer(), sdkMsgServer)
 
-	// TO-DO to be activated later
+	// TODO(#208) to be activated later
 	// types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(sdkMsgServer, am.keeper, am.accountKeeper, am.randomnessKeeper))
 
 	querier := sdkkeeper.Querier{Keeper: am.keeper.Keeper}

--- a/x/vesting/simulation/operations.go
+++ b/x/vesting/simulation/operations.go
@@ -124,7 +124,7 @@ func SimulateMsgCreateVestingAccount(
 			return simtypes.NoOpMsg(types.ModuleName, sdk.MsgTypeURL(msg), "unable to deliver tx"), nil, err
 		}
 
-		// TO-DO activate future operations
+		// TODO(#219) activate future operations
 		// // future operations
 		var futureOps []simtypes.FutureOperation
 		// // recipient stakes
@@ -240,7 +240,7 @@ func simulateMsgDelegate(
 
 		// simAccount, _ := simtypes.RandomAcc(r, accs)
 
-		// TO-DO: spare first two validators so we don't crash the network
+		// Spare first two validators so we don't crash the network.
 		val, ok := testutil.RandSliceElem(r, vals[2:])
 		if !ok {
 			return simtypes.NoOpMsg(types.ModuleName, msgType, "unable to pick a validator"), nil, nil

--- a/x/wasm-storage/keeper/msg_server_test.go
+++ b/x/wasm-storage/keeper/msg_server_test.go
@@ -64,18 +64,6 @@ func (s *KeeperTestSuite) TestStoreDataRequestWasm() {
 			expErr:    true,
 			expErrMsg: "data Request Wasm with given hash already exists",
 		},
-		// TO-DO: Add after migrating ValidateBasic logic
-		// {
-		// 	name: "inconsistent Wasm type",
-		// 	input: types.MsgStoreDataRequestWasm{
-		// 		Sender:   s.authority,
-		// 		Wasm:     regWasmZipped,
-		// 		WasmType: types.WasmTypeRelayer,
-		// 	},
-		// 	preRun:    func() {},
-		// 	expErr:    true,
-		// 	expErrMsg: "not a Data Request Wasm",
-		// },
 		{
 			name: "unzipped Wasm",
 			input: types.MsgStoreDataRequestWasm{


### PR DESCRIPTION
## Motivation

Cleaning up TODO comments.

- Avoid writing TODO comments as much as possible.
- Add an issue if possible like `TODO(#220)`
- Rename `TO-DO` to `TODO`