### PR TITLE
refactor: set default minimum gas prices

### DIFF
--- a/app/params/config.go
+++ b/app/params/config.go
@@ -33,6 +33,8 @@ var (
 	Bech32PrefixConsAddr = Bech32PrefixAccAddr + "valcons"
 	// Bech32PrefixConsPub defines the Bech32 prefix of a consensus node public key.
 	Bech32PrefixConsPub = Bech32PrefixAccAddr + "valconspub"
+
+	MinimumGasPrice = sdk.NewDecCoinFromDec(BaseCoinUnit, math.LegacyMustNewDecFromStr("100000000000")) // 10^11 aseda
 )
 
 func getSedaExponent() int64 {

--- a/cmd/sedad/cmd/config_defaults.go
+++ b/cmd/sedad/cmd/config_defaults.go
@@ -6,6 +6,8 @@ import (
 	tmcfg "github.com/cometbft/cometbft/config"
 
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+
+	"github.com/sedaprotocol/seda-chain/app/params"
 )
 
 // initTendermintConfig helps to override default Tendermint Config values.
@@ -52,7 +54,7 @@ func initAppConfig() (string, interface{}) {
 	//   own app.toml to override, or use this default value.
 	//
 	// In simapp, we set the min gas prices to 0.
-	srvCfg.MinGasPrices = "100000000000aseda" // 10^11 aseda
+	srvCfg.MinGasPrices = params.MinimumGasPrice.String()
 
 	// GRPC settings
 	srvCfg.GRPC.Enable = true

--- a/cmd/sedad/cmd/config_defaults.go
+++ b/cmd/sedad/cmd/config_defaults.go
@@ -52,7 +52,7 @@ func initAppConfig() (string, interface{}) {
 	//   own app.toml to override, or use this default value.
 	//
 	// In simapp, we set the min gas prices to 0.
-	srvCfg.MinGasPrices = "0seda"
+	srvCfg.MinGasPrices = "100000000000aseda" // 10^11 aseda
 
 	// GRPC settings
 	srvCfg.GRPC.Enable = true


### PR DESCRIPTION
Set the default minimum gas prices to 10^11 aseda. Validators can tweak this local configuration value in app.toml.


