### PR TITLE
Plugin logging and error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2
+	github.com/hashicorp/go-hclog v1.6.2
 	github.com/hashicorp/go-metrics v0.5.3
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/ory/dockertest/v3 v3.10.0
@@ -138,7 +139,6 @@ require (
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-getter v1.7.3 // indirect
-	github.com/hashicorp/go-hclog v1.6.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect

--- a/plugins/indexing/README.md
+++ b/plugins/indexing/README.md
@@ -26,6 +26,84 @@ The plugin uses [Hashicorp's hclog](https://pkg.go.dev/github.com/hashicorp/go-h
 
 Since we've been unable to get the plugin log output to show up in the node output for now we resort to logging to a file. A benefit is that this makes monitoring the plugin easier since we don't have to filter out any node logs. When deploying the plugin and configuring the log file make sure to set up log rotation for the log output directory.
 
+### Disaster Recovery
+
+When the plugin fails to process updates it halts the node (provided the `stop-node-on-err` setting in the `app.toml` file is set to `true). This makes it easier for us to resume the indexing process from the point where the failure occurred, but there are a few caveats to keep in mind with how the node handles these errors.
+
+If we simplify things there are 3 points of failure in the plugin:
+
+1. [Errors during the initialisation of the plugin](#plugin-initialisation-errors).
+2. [Errors while processing the `ListenFinalizeBlock` handler](#listenfinalizeblock-errors).
+3. [Errors while processing the `ListenCommit` handler](#listencommit-errors).
+
+#### Plugin Initialisation Errors
+
+Most of these errors should be related to incorrect configuration or missing environment variables. These errors will prevent the SEDA node process from starting altogether with a trace like the following:
+
+```txt
+panic: failed to load streaming plugin: <MESSAGE_FROM_PLUGIN>
+This usually means
+  the plugin was not compiled for this architecture,
+  the plugin is missing dynamic-link libraries necessary to run,
+  the plugin is not executable by this process due to file permissions, or
+  the plugin failed to negotiate the initial go-plugin protocol handshake
+
+Additional notes about plugin:
+  Path: /bin/sh
+  Mode: -rwxr-xr-x
+  Owner: 0 [root] (current: 501 [user])
+  Group: 0 [wheel] (current: 20 [staff])
+
+# Omitted long stacktrace which is not very helpful.
+```
+
+`<MESSAGE_FROM_PLUGIN>` usually is a string with the error message from the plugin, but it could be missing in case it's an unhandled panic thrown somewhere during the plugin initialisation.
+
+Since the node didn't even start running we don't have to worry about block/state mismatches and can just fix the plugin/configuration and restart the process.
+
+#### ListenFinalizeBlock Errors
+
+These errors are are most likely related to the processing of block/transaction data or publishing the messages on the queue. These errors halt the chain with an error message like the following:
+
+```txt
+1:16PM ERR FinalizeBlock listening hook failed err="rpc error: code = Unknown desc = <MESSAGE_FROM_PLUGIN>" height=XXX module=server
+2024-03-26T13:16:10.507+0100 [INFO]  plugin.abci: plugin process exited: plugin=/bin/sh id=14714
+```
+
+`<MESSAGE_FROM_PLUGIN>` usually is a string with the error message from the plugin, but it could be missing in case it's an unhandled error/panic.
+
+These errors are also fairly easy to recover from. When restarting the node it will 'notice' a discrepancy between the state height and store height, where the store height (N) is where the error occurred:
+
+```txt
+1:16PM INF ABCI Replay Blocks appHeight=N-1 module=consensus stateHeight=N-1 storeHeight=N
+1:16PM INF Replay last block using real app module=consensus
+```
+
+As the logs indicate the node will replay the last block in order to update the state and app. This means the `ListenFinalizeBlock` handler is called again for height N. As long as the indexer is capabale of handling duplicate messages there are no further actions to take. Provided that the plugin has been fixed/problem has been resolved the indexing should be able to continue.
+
+#### ListenCommit Errors
+
+These errors are are most likely related to the processing of state data or publishing the messages on the queue. These errors halt the chain with an error message like the following:
+
+```txt
+1:12PM ERR Commit listening hook failed err="rpc error: code = Unknown desc = <MESSAGE_FROM_PLUGIN>" height=404 module=server
+2024-03-26T13:12:24.905+0100 [INFO]  plugin.abci: plugin process exited: plugin=/bin/sh id=13031
+```
+
+`<MESSAGE_FROM_PLUGIN>` usually is a string with the error message from the plugin, but it could be missing in case it's an unhandled error/panic.
+
+These errors are the most tricky to recover from as the node will have updated its state and app, so restarting will resume the node at height N+1, where N is the height at which the error occurred. In order to reprocess height N the node needs to be rolled back 1 block:
+
+```sh
+sedad rollback
+# Rolled back state to height N and hash XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX%
+```
+
+> [!WARNING]
+> Even though this command does not invoke any callbacks on the plugin it still initialises it and as such requires the required environment variables to be present in the shell that executes the command.
+
+Now the node can be restarted and it should resume from height N. It will call both `ListenFinalizeBlock` and `ListenCommit` again for that height, so as long as the indexer is capable of handling duplicate messages everything should be able to continue (provided that the plugin has been fixed/problem has been resolved).
+
 ## Building
 
 ```sh

--- a/plugins/indexing/README.md
+++ b/plugins/indexing/README.md
@@ -13,9 +13,18 @@ The process that starts the node should have the following environment variables
 ```sh
 export COSMOS_SDK_ABCI=PATH_TO_PLUGIN_EXECUTABLE
 export SQS_QUEUE_URL=""
+export PLUGIN_LOG_FILE=PATH_TO_DESIRED_LOG_FILE
+# Optionally you can also specify the log level, one of "trace", "debug", "info", "warn", "error"
+export PLUGIN_LOG_LEVEL="WARN"
 ```
 
 Lastly, as we're using SQS the node needs access to a valid set of AWS credentials with permission to publish messages to the specified queue.
+
+### Logging
+
+The plugin uses [Hashicorp's hclog](https://pkg.go.dev/github.com/hashicorp/go-hclog) as this is the recommended approach in go-plugins and is also what the StreamingManager sets up on the Cosmos SDK side.
+
+Since we've been unable to get the plugin log output to show up in the node output for now we resort to logging to a file. A benefit is that this makes monitoring the plugin easier since we don't have to filter out any node logs. When deploying the plugin and configuring the log file make sure to set up log rotation for the log output directory.
 
 ## Building
 

--- a/plugins/indexing/bank/module.go
+++ b/plugins/indexing/bank/module.go
@@ -10,12 +10,13 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
+	log "github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	types "github.com/sedaprotocol/seda-chain/plugins/indexing/types"
 )
 
 const StoreKey = banktypes.StoreKey
 
-func ExtractUpdate(_ codec.Codec, change *storetypes.StoreKVPair) (*types.Message, error) {
+func ExtractUpdate(_ codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
 	if keyBytes, found := bytes.CutPrefix(change.Key, banktypes.SupplyKey); found {
 		_, key, err := collections.StringKey.Decode(keyBytes)
 		if err != nil {
@@ -62,6 +63,6 @@ func ExtractUpdate(_ codec.Codec, change *storetypes.StoreKVPair) (*types.Messag
 		return types.NewMessage("account-balance", data), nil
 	}
 
-	// TODO(#217) Log warning ("unable to process change %v", change)
+	logger.Trace("skipping change", "change", change)
 	return nil, nil
 }

--- a/plugins/indexing/log/logger.go
+++ b/plugins/indexing/log/logger.go
@@ -1,0 +1,92 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+var (
+	logFileEnvName  = "PLUGIN_LOG_FILE"
+	logLevelEnvName = "PLUGIN_LOG_LEVEL"
+)
+
+type Logger struct {
+	baseLogger hclog.Logger
+}
+
+func (l *Logger) Trace(msg string, args ...interface{}) {
+	l.baseLogger.Trace(msg, args...)
+}
+
+func (l *Logger) Debug(msg string, args ...interface{}) {
+	l.baseLogger.Debug(msg, args...)
+}
+
+func (l *Logger) Info(msg string, args ...interface{}) {
+	l.baseLogger.Info(msg, args...)
+}
+
+func (l *Logger) Warn(msg string, args ...interface{}) {
+	l.baseLogger.Warn(msg, args...)
+}
+
+func (l *Logger) Error(msg string, args ...interface{}) {
+	l.baseLogger.Error(msg, args...)
+}
+
+// Fatal is equivalent to Error(msg, "error", err) followed by a call to panic(err)
+func (l *Logger) Fatal(msg string, err error) {
+	l.baseLogger.Error(msg, "error", err)
+	// Also printing to stdout so the plugin server error message is more informative
+	fmt.Println(err)
+	panic(err)
+}
+
+func GetLogFile() (*os.File, error) {
+	logFileName, found := os.LookupEnv(logFileEnvName)
+	if !found {
+		err := fmt.Errorf("missing environment variable '%s'", logFileEnvName)
+		return nil, err
+	}
+
+	logFile, err := os.OpenFile(logFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		return nil, err
+	}
+
+	return logFile, nil
+}
+
+func NewLogger(output io.Writer) *Logger {
+	logLevel, found := os.LookupEnv(logLevelEnvName)
+	if !found {
+		logLevel = "default"
+	}
+
+	return &Logger{
+		baseLogger: hclog.New(&hclog.LoggerOptions{
+			Output: output,
+			Level:  toHclogLevel(logLevel),
+		}),
+	}
+}
+
+func toHclogLevel(s string) hclog.Level {
+	switch s {
+	case "trace":
+		return hclog.Trace
+	case "debug":
+		return hclog.Debug
+	case "info":
+		return hclog.Info
+	case "warn":
+		return hclog.Warn
+	case "error":
+		return hclog.Error
+	default:
+		return hclog.DefaultLevel
+	}
+}

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -118,9 +118,14 @@ func main() {
 	std.RegisterInterfaces(interfaceRegistry)
 	app.ModuleBasics.RegisterInterfaces(interfaceRegistry)
 
+	sqsClient, err := pluginsqs.NewSqsClient()
+	if err != nil {
+		logger.Fatal("failed to create sqs client", err)
+	}
+
 	filePlugin := &IndexerPlugin{
 		cdc:       codec.NewProtoCodec(interfaceRegistry),
-		sqsClient: pluginsqs.NewSqsClient(),
+		sqsClient: sqsClient,
 		logger:    logger,
 	}
 

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/go-plugin"
 
 	streamingabci "cosmossdk.io/store/streaming/abci"
 	storetypes "cosmossdk.io/store/types"
-
 	"cosmossdk.io/x/tx/signing"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -21,6 +21,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/app/params"
 
 	bankmodule "github.com/sedaprotocol/seda-chain/plugins/indexing/bank"
+	log "github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	pluginsqs "github.com/sedaprotocol/seda-chain/plugins/indexing/sqs"
 	types "github.com/sedaprotocol/seda-chain/plugins/indexing/types"
 )
@@ -33,46 +34,65 @@ type IndexerPlugin struct {
 	blockHeight int64
 	cdc         codec.Codec
 	sqsClient   *pluginsqs.SqsClient
+	logger      *log.Logger
 }
 
 func (p *IndexerPlugin) ListenFinalizeBlock(_ context.Context, req abci.RequestFinalizeBlock, _ abci.ResponseFinalizeBlock) error {
+	p.logger.Debug(fmt.Sprintf("[%d] Start processing finalize block.", req.Height))
 	p.blockHeight = req.Height
 
+	p.logger.Debug(fmt.Sprintf("[%d] Processed finalize block.", req.Height))
 	return nil
 }
 
 func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Message, error) {
 	switch change.StoreKey {
 	case bankmodule.StoreKey:
-		return bankmodule.ExtractUpdate(p.cdc, change)
+		return bankmodule.ExtractUpdate(p.cdc, p.logger, change)
 	default:
 		return nil, nil
 	}
 }
 
 func (p *IndexerPlugin) ListenCommit(_ context.Context, _ abci.ResponseCommit, changeSet []*storetypes.StoreKVPair) error {
+	p.logger.Debug(fmt.Sprintf("[%d] Start processing commit", p.blockHeight))
 	var messages []*types.Message
 
 	for _, change := range changeSet {
 		message, err := p.extractUpdate(change)
 		if err != nil {
+			p.logger.Error("Failed to extract update", "error", err)
 			return err
 		}
 
 		if message != nil {
+			p.logger.Debug("Extracted update", "message", message)
 			messages = append(messages, message)
 		}
 	}
 
 	publishError := p.sqsClient.PublishToQueue(p.blockHeight, messages)
 	if publishError != nil {
+		p.logger.Error("Failed to publish messages to queue.", "error", publishError)
 		return publishError
 	}
 
+	p.logger.Debug(fmt.Sprintf("[%d] Processed commit", p.blockHeight))
 	return nil
 }
 
 func main() {
+	logFile, err := log.GetLogFile()
+	if err != nil {
+		// Printing the error makes it easier to see what went wrong in the plugin output
+		fmt.Println(err)
+		panic(err)
+	}
+	defer logFile.Close()
+
+	logger := log.NewLogger(logFile)
+	logger.Info("initialising plugin")
+
 	// Configure address prefixes.
 	cfg := sdk.GetConfig()
 	cfg.SetBech32PrefixForAccount(params.Bech32PrefixAccAddr, params.Bech32PrefixAccPub)
@@ -93,7 +113,7 @@ func main() {
 		},
 	})
 	if err != nil {
-		panic(err)
+		logger.Fatal("failed to create interface registry", err)
 	}
 	std.RegisterInterfaces(interfaceRegistry)
 	app.ModuleBasics.RegisterInterfaces(interfaceRegistry)
@@ -101,8 +121,10 @@ func main() {
 	filePlugin := &IndexerPlugin{
 		cdc:       codec.NewProtoCodec(interfaceRegistry),
 		sqsClient: pluginsqs.NewSqsClient(),
+		logger:    logger,
 	}
 
+	logger.Info("finished initialising plugin")
 	plugin.Serve(&plugin.ServeConfig{
 		HandshakeConfig: streamingabci.Handshake,
 		Plugins: map[string]plugin.Plugin{

--- a/plugins/indexing/sqs/sqs_client.go
+++ b/plugins/indexing/sqs/sqs_client.go
@@ -82,15 +82,15 @@ func (sc *SqsClient) PublishToQueue(height int64, data []*types.Message) error {
 	return nil
 }
 
-func NewSqsClient() *SqsClient {
+func NewSqsClient() (*SqsClient, error) {
 	queueURL, found := os.LookupEnv(queueURLEnvName)
 	if !found {
-		panic(fmt.Errorf("missing environment variable '%s'", queueURLEnvName))
+		return nil, fmt.Errorf("missing environment variable '%s'", queueURLEnvName)
 	}
 
 	sess, err := NewSession()
 	if err != nil {
-		panic(fmt.Errorf("failed to initialise session: %w", err))
+		return nil, fmt.Errorf("failed to initialise session: %w", err)
 	}
 
 	awsSqsClient := sqs.New(sess)
@@ -98,5 +98,5 @@ func NewSqsClient() *SqsClient {
 	return &SqsClient{
 		sqsClient: awsSqsClient,
 		queueURL:  queueURL,
-	}
+	}, nil
 }


### PR DESCRIPTION
## Motivation

With a logger in place it's a lot easier to debug issues during development and add error monitoring in production. The 'disaster' recovery section explains which actions to take depending on where in the process the error occurred.

## Explanation of Changes

I looked at other Golang projects to see how they handle wrapper around libraries or do error handling so hopefully it's all rather straightforward.

I added the `abort` helper in `plugins/indexing/plugin.go` to make initialisation errors easier to process. For some reason `panic` calls do not (always?) show up in the log output of the node, but if we first log it to stdout they always show. We don't need it in the `ListenX` handlers as the errors returned from these functions are always printed in the node logs.

## Testing

Logging tested by running the chain locally with the following env variables from the repo root:

```sh
make build-plugin-dev && PLUGIN_LOG_FILE="$(pwd)/test.log" PLUGIN_LOG_LEVEL="trace" $BIN start
```

This does assume a chain build is present and the `$BIN` variable points to the executable.

You should see a `test.log` file being created and as blocks get processed entries for both handlers should appear.

Error handling/disaster recovery tested with the following methods:
- Not proving required environment variables when starting the chain.
- Turning off the queue emulator while the chain/plugin were running.
- Manually panicking/returning errors from the `ListenFinalizeBlock` and `ListenCommit` handlers.

## Related PRs and Issues

Closes: #217, #218