### PR TITLE
Publish block data

### DIFF
--- a/plugins/indexing/base/block.go
+++ b/plugins/indexing/base/block.go
@@ -1,0 +1,35 @@
+package base
+
+import (
+	"encoding/hex"
+	"strings"
+	"time"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	types "github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+)
+
+func ExtractBlockUpdate(req abci.RequestFinalizeBlock) (*types.Message, error) {
+	hash := strings.ToUpper(hex.EncodeToString(req.Hash))
+	txCount := len(req.Txs)
+	proposerAddress, err := sdk.ConsAddressFromHex(hex.EncodeToString(req.ProposerAddress))
+	if err != nil {
+		return nil, err
+	}
+
+	data := struct {
+		Hash            string    `json:"hash"`
+		Time            time.Time `json:"time"`
+		TxCount         int       `json:"txCount"`
+		ProposerAddress string    `json:"proposerAddress"`
+	}{
+		Hash:            hash,
+		Time:            req.Time,
+		TxCount:         txCount,
+		ProposerAddress: proposerAddress.String(),
+	}
+
+	return types.NewMessage("block", data), nil
+}

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/app/params"
 
 	bankmodule "github.com/sedaprotocol/seda-chain/plugins/indexing/bank"
+	base "github.com/sedaprotocol/seda-chain/plugins/indexing/base"
 	log "github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	pluginsqs "github.com/sedaprotocol/seda-chain/plugins/indexing/sqs"
 	types "github.com/sedaprotocol/seda-chain/plugins/indexing/types"
@@ -37,9 +38,34 @@ type IndexerPlugin struct {
 	logger      *log.Logger
 }
 
+func (p *IndexerPlugin) publishToQueue(messages []*types.Message) error {
+	publishError := p.sqsClient.PublishToQueue(p.blockHeight, messages)
+	if publishError != nil {
+		p.logger.Error("Failed to publish messages to queue.", "error", publishError)
+		return publishError
+	}
+
+	return nil
+}
+
 func (p *IndexerPlugin) ListenFinalizeBlock(_ context.Context, req abci.RequestFinalizeBlock, _ abci.ResponseFinalizeBlock) error {
 	p.logger.Debug(fmt.Sprintf("[%d] Start processing finalize block.", req.Height))
 	p.blockHeight = req.Height
+	var messages []*types.Message
+
+	blockMessage, err := base.ExtractBlockUpdate(req)
+	if err != nil {
+		p.logger.Error("Failed to extract block update", "error", err)
+		return err
+	}
+	messages = append(messages, blockMessage)
+
+	// TODO(#223) Extract all transaction data.
+	// TODO(#229) Extract all vote data.
+
+	if err := p.publishToQueue(messages); err != nil {
+		return err
+	}
 
 	p.logger.Debug(fmt.Sprintf("[%d] Processed finalize block.", req.Height))
 	return nil
@@ -71,10 +97,8 @@ func (p *IndexerPlugin) ListenCommit(_ context.Context, _ abci.ResponseCommit, c
 		}
 	}
 
-	publishError := p.sqsClient.PublishToQueue(p.blockHeight, messages)
-	if publishError != nil {
-		p.logger.Error("Failed to publish messages to queue.", "error", publishError)
-		return publishError
+	if err := p.publishToQueue(messages); err != nil {
+		return err
 	}
 
 	p.logger.Debug(fmt.Sprintf("[%d] Processed commit", p.blockHeight))


### PR DESCRIPTION
## Explanation of Changes

I opted for a `base` package so it can house the 'base' components (blocks, TXs, validator votes). Open to suggestions for a better name. :)

## Testing

You can 'just' set up the plugin, queue emulator, and start a local node. You should start seeing messages getting added to the queue:

```txt
{"level":"info","msg":"2024-03-27 07:51:17: Queue: local-updates.fifo, Message: {\"type\":\"block\",\"data\":{\"hash\":\"4B8C19CDBA69F4B032BCE5510821C9E644344BB74F76609287F4850C72F8E62F\",\"time\":\"2024-03-27T07:51:10.171833Z\",\"txCount\":0,\"proposerAddress\":\"sedavalcons1v73gscruflrq343ej403dkxcgczel6zlhpd5sg\"}}\n","time":"2024-03-27T07:51:17Z"}
```

Just the message:
```json
{
  "type": "block",
  "data": {
    "hash": "4B8C19CDBA69F4B032BCE5510821C9E644344BB74F76609287F4850C72F8E62F",
    "time": "2024-03-27T07:51:10.171833Z",
    "txCount": 0,
    "proposerAddress": "sedavalcons1v73gscruflrq343ej403dkxcgczel6zlhpd5sg"
  }
}
```

## Related PRs and Issues

Closes: #222
Spawns: #229 
