### PR TITLE
test: add clawback simulation testing using Cosmos fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -236,3 +236,5 @@ require (
 )
 
 replace github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
+
+replace github.com/cosmos/cosmos-sdk v0.50.5 => github.com/hacheigriega/cosmos-sdk v0.50.5-sim-test

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,6 @@ github.com/cosmos/cosmos-db v1.0.2 h1:hwMjozuY1OlJs/uh6vddqnk9j7VamLv+0DBlbEXbAK
 github.com/cosmos/cosmos-db v1.0.2/go.mod h1:Z8IXcFJ9PqKK6BIsVOB3QXtkKoqUOp1vRvPT39kOXEA=
 github.com/cosmos/cosmos-proto v1.0.0-beta.4 h1:aEL7tU/rLOmxZQ9z4i7mzxcLbSCY48OdY7lIWTLG7oU=
 github.com/cosmos/cosmos-proto v1.0.0-beta.4/go.mod h1:oeB+FyVzG3XrQJbJng0EnV8Vljfk9XvTIpGILNU/9Co=
-github.com/cosmos/cosmos-sdk v0.50.5 h1:MOEi+DKYgW67YaPgB+Pf+nHbD3V9S/ayitRKJYLfGIA=
-github.com/cosmos/cosmos-sdk v0.50.5/go.mod h1:oV/k6GJgXV9QPoM2fsYDPPsyPBgQbdotv532O6Mz1OQ=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
 github.com/cosmos/gogogateway v1.2.0 h1:Ae/OivNhp8DqBi/sh2A8a1D0y638GpL3tkmLQAiKxTE=
@@ -683,6 +681,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbsk
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c/go.mod h1:NMPJylDgVpX0MLRlPy15sqSwOFv/U1GZ2m21JhFfek0=
+github.com/hacheigriega/cosmos-sdk v0.50.5-sim-test h1:TNNxox4PpqwwVB8RZBAeYq0y42BO8+pTDJ+pQPm24EM=
+github.com/hacheigriega/cosmos-sdk v0.50.5-sim-test/go.mod h1:oV/k6GJgXV9QPoM2fsYDPPsyPBgQbdotv532O6Mz1OQ=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -3,7 +3,6 @@ package app_test
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -123,7 +122,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	config.AllInvariants = true
 
 	var (
-		r                    = rand.New(rand.NewSource(time.Now().Unix()))
+		// r                    = rand.New(rand.NewSource(time.Now().Unix()))
 		numSeeds             = 3
 		numTimesToRunPerSeed = 5
 		appHashList          = make([]json.RawMessage, numTimesToRunPerSeed)
@@ -133,7 +132,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
 	for i := 0; i < numSeeds; i++ {
-		config.Seed = r.Int63()
+		config.Seed = 6889705512020126020 //r.Int63()
 
 		for j := 0; j < numTimesToRunPerSeed; j++ {
 			var logger log.Logger

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -122,7 +123,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	config.AllInvariants = true
 
 	var (
-		// r                    = rand.New(rand.NewSource(time.Now().Unix()))
+		r                    = rand.New(rand.NewSource(time.Now().Unix()))
 		numSeeds             = 3
 		numTimesToRunPerSeed = 5
 		appHashList          = make([]json.RawMessage, numTimesToRunPerSeed)
@@ -132,7 +133,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
 	for i := 0; i < numSeeds; i++ {
-		config.Seed = 6889705512020126020 //r.Int63()
+		config.Seed = r.Int63()
 
 		for j := 0; j < numTimesToRunPerSeed; j++ {
 			var logger log.Logger

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -3,7 +3,6 @@ package app_test
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -123,7 +122,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	config.AllInvariants = true
 
 	var (
-		r                    = rand.New(rand.NewSource(time.Now().Unix()))
+		// r                    = rand.New(rand.NewSource(time.Now().Unix()))
 		numSeeds             = 3
 		numTimesToRunPerSeed = 5
 		appHashList          = make([]json.RawMessage, numTimesToRunPerSeed)
@@ -133,7 +132,7 @@ func TestAppStateDeterminism(t *testing.T) {
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 
 	for i := 0; i < numSeeds; i++ {
-		config.Seed = r.Int63()
+		config.Seed = 1055780109962885907 //r.Int63()
 
 		for j := 0; j < numTimesToRunPerSeed; j++ {
 			var logger log.Logger

--- a/x/vesting/keeper/msg_server.go
+++ b/x/vesting/keeper/msg_server.go
@@ -258,6 +258,11 @@ func (m msgServer) Clawback(goCtx context.Context, msg *types.MsgClawback) (*typ
 		}
 	}
 
+	fmt.Printf("\nunbonded: %s\nunbonding: %s\nbonded: %s\n\n\n",
+		clawedBackUnbonded.String(),
+		clawedBackUnbonding.String(),
+		clawedBackBonded.String(),
+	)
 	return &types.MsgClawbackResponse{
 		ClawedUnbonded:  clawedBackUnbonded,
 		ClawedUnbonding: clawedBackUnbonding,

--- a/x/vesting/keeper/msg_server.go
+++ b/x/vesting/keeper/msg_server.go
@@ -258,11 +258,11 @@ func (m msgServer) Clawback(goCtx context.Context, msg *types.MsgClawback) (*typ
 		}
 	}
 
-	fmt.Printf("\nunbonded: %s\nunbonding: %s\nbonded: %s\n\n\n",
-		clawedBackUnbonded.String(),
-		clawedBackUnbonding.String(),
-		clawedBackBonded.String(),
-	)
+	// fmt.Printf("\nunbonded: %s\nunbonding: %s\nbonded: %s\n\n\n",
+	// 	clawedBackUnbonded.String(),
+	// 	clawedBackUnbonding.String(),
+	// 	clawedBackBonded.String(),
+	// )
 	return &types.MsgClawbackResponse{
 		ClawedUnbonded:  clawedBackUnbonded,
 		ClawedUnbonding: clawedBackUnbonding,

--- a/x/vesting/simulation/operations.go
+++ b/x/vesting/simulation/operations.go
@@ -412,8 +412,8 @@ func simulateMsgRedelegate(
 			return simtypes.NoOpMsg(types.ModuleName, msgType, "error getting validator delegations"), nil, nil
 		}
 		totalBond := srcVal.TokensFromShares(delegation.GetShares()).TruncateInt()
-		if !totalBond.IsPositive() {
-			return simtypes.NoOpMsg(types.ModuleName, msgType, "total bond is negative"), nil, nil
+		if totalBond.LTE(math.OneInt()) {
+			return simtypes.NoOpMsg(types.ModuleName, msgType, "total bond is less than equal to one"), nil, nil
 		}
 
 		amount := totalBond

--- a/x/vesting/simulation/operations.go
+++ b/x/vesting/simulation/operations.go
@@ -252,6 +252,9 @@ func simulateMsgDelegate(
 
 		account := ak.GetAccount(ctx, acc.Address)
 		delAmt := sdk.NewCoin(originalVesting.Denom, originalVesting.Amount.Quo(math.NewInt(maxNumDelegate)))
+		if !delAmt.IsPositive() {
+			return simtypes.NoOpMsg(types.ModuleName, msgType, "invalid delegation amount"), nil, nil
+		}
 		fees := sdk.NewCoins()
 
 		msg := stakingtypes.NewMsgDelegate(acc.Address.String(), val.GetOperator(), delAmt)

--- a/x/vesting/types/expected_keepers.go
+++ b/x/vesting/types/expected_keepers.go
@@ -34,4 +34,7 @@ type StakingKeeper interface {
 	GetDelegatorDelegations(ctx context.Context, delegator sdk.AccAddress, maxRetrieve uint16) (delegations []types.Delegation, err error)
 	TransferUnbonding(ctx context.Context, fromAddr, toAddr sdk.AccAddress, valAddr sdk.ValAddress, wantAmt math.Int) (math.Int, error)
 	TransferDelegation(ctx context.Context, fromAddr, toAddr sdk.AccAddress, valAddr sdk.ValAddress, wantShares math.LegacyDec) (math.LegacyDec, error)
+	// For simulation testing
+	GetDelegation(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (types.Delegation, error)
+	ValidateUnbondAmount(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt math.Int) (shares math.LegacyDec, err error)
 }

--- a/x/vesting/types/expected_keepers.go
+++ b/x/vesting/types/expected_keepers.go
@@ -36,5 +36,6 @@ type StakingKeeper interface {
 	TransferDelegation(ctx context.Context, fromAddr, toAddr sdk.AccAddress, valAddr sdk.ValAddress, wantShares math.LegacyDec) (math.LegacyDec, error)
 	// For simulation testing
 	GetDelegation(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress) (types.Delegation, error)
+	HasReceivingRedelegation(ctx context.Context, delAddr sdk.AccAddress, valDstAddr sdk.ValAddress) (bool, error)
 	ValidateUnbondAmount(ctx context.Context, delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt math.Int) (shares math.LegacyDec, err error)
 }


### PR DESCRIPTION
## Explanation of Changes

- [x] Use `replace` directive to import Cosmos SDK fork that includes a (partial) fix to the simulation testing persistence issue.
- [x] Add clawback operations as future operations that would follow vesting account creation operations.
- [x] Add delegation, re-delegation, and un-delegation operations to test clawbacks of bonded and unbonding vesting tokens.
- [x] Ensure that invariants are always checked.
- [ ] Merge to a separate branch.

Closes: #219 


