### PR TITLE
Publish account data

### DIFF
--- a/plugins/indexing/auth/module.go
+++ b/plugins/indexing/auth/module.go
@@ -1,0 +1,38 @@
+package bank
+
+import (
+	"bytes"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	log "github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	types "github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+)
+
+const StoreKey = authtypes.StoreKey
+
+type wrappedAccount struct {
+	cdc     codec.Codec
+	Account sdk.AccountI
+}
+
+func (s wrappedAccount) MarshalJSON() ([]byte, error) {
+	return s.cdc.MarshalInterfaceJSON(s.Account)
+}
+
+func ExtractUpdate(cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+	if _, found := bytes.CutPrefix(change.Key, authtypes.AddressStoreKeyPrefix); found {
+		acc, err := codec.CollInterfaceValue[sdk.AccountI](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return types.NewMessage("account", &wrappedAccount{cdc: cdc, Account: acc}), nil
+	}
+
+	logger.Trace("skipping change", "change", change)
+	return nil, nil
+}

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/app"
 	"github.com/sedaprotocol/seda-chain/app/params"
 
+	authmodule "github.com/sedaprotocol/seda-chain/plugins/indexing/auth"
 	bankmodule "github.com/sedaprotocol/seda-chain/plugins/indexing/bank"
 	base "github.com/sedaprotocol/seda-chain/plugins/indexing/base"
 	log "github.com/sedaprotocol/seda-chain/plugins/indexing/log"
@@ -81,6 +82,8 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 	switch change.StoreKey {
 	case bankmodule.StoreKey:
 		return bankmodule.ExtractUpdate(p.cdc, p.logger, change)
+	case authmodule.StoreKey:
+		return authmodule.ExtractUpdate(p.cdc, p.logger, change)
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
## Explanation of Changes

Marshalling with the interface gives us an identifier for the account type, which we can use on the indexer side to know how to unpack the object.

## Testing

You can 'just' set up the plugin, queue emulator, and start a local node. When it starts you should see all the genesis accounts being indexed in block 1:

```json
{"level":"info","msg":"2024-04-08 11:26:55: Queue: local-updates.fifo, Message: {\"type\":\"account\",\"data\":{\"@type\":\"/cosmos.auth.v1beta1.ModuleAccount\",\"base_account\":{\"address\":\"seda1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3r49h6k\",\"pub_key\":null,\"account_number\":\"7\",\"sequence\":\"0\"},\"name\":\"bonded_tokens_pool\",\"permissions\":[\"burner\",\"staking\"]}}\n","time":"2024-04-08T11:26:55Z"}
{"level":"info","msg":"2024-04-08 11:26:55: Queue: local-updates.fifo, Message: {\"type\":\"account\",\"data\":{\"@type\":\"/cosmos.auth.v1beta1.BaseAccount\",\"address\":\"seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah\",\"pub_key\":null,\"account_number\":\"2\",\"sequence\":\"0\"}}\n","time":"2024-04-08T11:26:55Z"}
```

Just the messages:
```json
{
  "type": "account",
  "data": {
    "@type": "/cosmos.auth.v1beta1.ModuleAccount",
    "base_account": {
      "address": "seda1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3r49h6k",
      "pub_key": null,
      "account_number": "7",
      "sequence": "0"
    },
    "name": "bonded_tokens_pool",
    "permissions": ["burner", "staking"]
  }
}
```

```json
{
  "type": "account",
  "data": {
    "@type": "/cosmos.auth.v1beta1.BaseAccount",
    "address": "seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah",
    "pub_key": null,
    "account_number": "2",
    "sequence": "0"
  }
}
```

When you submit transactions you'll also messages for the account with the increased sequence number.

## Related PRs and Issues

Closes: #227
