### PR TITLE
Publish timestamp

### DIFF
--- a/plugins/indexing/auth/module.go
+++ b/plugins/indexing/auth/module.go
@@ -23,14 +23,14 @@ func (s wrappedAccount) MarshalJSON() ([]byte, error) {
 	return s.cdc.MarshalInterfaceJSON(s.Account)
 }
 
-func ExtractUpdate(cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
 	if _, found := bytes.CutPrefix(change.Key, authtypes.AddressStoreKeyPrefix); found {
 		acc, err := codec.CollInterfaceValue[sdk.AccountI](cdc).Decode(change.Value)
 		if err != nil {
 			return nil, err
 		}
 
-		return types.NewMessage("account", &wrappedAccount{cdc: cdc, Account: acc}), nil
+		return types.NewMessage("account", &wrappedAccount{cdc: cdc, Account: acc}, ctx), nil
 	}
 
 	logger.Trace("skipping change", "change", change)

--- a/plugins/indexing/bank/module.go
+++ b/plugins/indexing/bank/module.go
@@ -16,7 +16,7 @@ import (
 
 const StoreKey = banktypes.StoreKey
 
-func ExtractUpdate(_ codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+func ExtractUpdate(ctx *types.BlockContext, _ codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
 	if keyBytes, found := bytes.CutPrefix(change.Key, banktypes.SupplyKey); found {
 		_, key, err := collections.StringKey.Decode(keyBytes)
 		if err != nil {
@@ -37,7 +37,7 @@ func ExtractUpdate(_ codec.Codec, logger *log.Logger, change *storetypes.StoreKV
 			Amount: amount.String(),
 		}
 
-		return types.NewMessage("supply", data), nil
+		return types.NewMessage("supply", data, ctx), nil
 	} else if keyBytes, found := bytes.CutPrefix(change.Key, banktypes.BalancesPrefix); found {
 		_, key, err := collections.PairKeyCodec(sdk.AccAddressKey, collections.StringKey).Decode(keyBytes)
 		if err != nil {
@@ -60,7 +60,7 @@ func ExtractUpdate(_ codec.Codec, logger *log.Logger, change *storetypes.StoreKV
 			Denom:   key.K2(),
 		}
 
-		return types.NewMessage("account-balance", data), nil
+		return types.NewMessage("account-balance", data, ctx), nil
 	}
 
 	logger.Trace("skipping change", "change", change)

--- a/plugins/indexing/base/block.go
+++ b/plugins/indexing/base/block.go
@@ -11,7 +11,7 @@ import (
 	types "github.com/sedaprotocol/seda-chain/plugins/indexing/types"
 )
 
-func ExtractBlockUpdate(req abci.RequestFinalizeBlock) (*types.Message, error) {
+func ExtractBlockUpdate(ctx *types.BlockContext, req abci.RequestFinalizeBlock) (*types.Message, error) {
 	hash := strings.ToUpper(hex.EncodeToString(req.Hash))
 	txCount := len(req.Txs)
 	proposerAddress, err := sdk.ConsAddressFromHex(hex.EncodeToString(req.ProposerAddress))
@@ -31,5 +31,5 @@ func ExtractBlockUpdate(req abci.RequestFinalizeBlock) (*types.Message, error) {
 		ProposerAddress: proposerAddress.String(),
 	}
 
-	return types.NewMessage("block", data), nil
+	return types.NewMessage("block", data, ctx), nil
 }

--- a/plugins/indexing/base/transaction.go
+++ b/plugins/indexing/base/transaction.go
@@ -22,7 +22,7 @@ func (s wrappedTx) MarshalJSON() ([]byte, error) {
 	return s.cdc.MarshalJSON(s.Tx)
 }
 
-func ExtractTransactionUpdates(cdc codec.Codec, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) ([]*types.Message, error) {
+func ExtractTransactionUpdates(ctx *types.BlockContext, cdc codec.Codec, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) ([]*types.Message, error) {
 	messages := make([]*types.Message, 0, len(req.Txs))
 
 	timestamp := req.Time
@@ -49,7 +49,7 @@ func ExtractTransactionUpdates(cdc codec.Codec, req abci.RequestFinalizeBlock, r
 			Result: txResult,
 		}
 
-		messages = append(messages, types.NewMessage("tx", data))
+		messages = append(messages, types.NewMessage("tx", data, ctx))
 	}
 
 	return messages, nil

--- a/plugins/indexing/sqs/sqs_client.go
+++ b/plugins/indexing/sqs/sqs_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sqs"
@@ -31,7 +32,7 @@ func (sc *SqsClient) sendMessageBatch(batch []*sqs.SendMessageBatchRequestEntry)
 	return result.Failed, nil
 }
 
-func (sc *SqsClient) PublishToQueue(height int64, data []*types.Message) error {
+func (sc *SqsClient) PublishToQueue(data []*types.Message) error {
 	// Remember max message size is 262,144 bytes
 	entries := make([]*sqs.SendMessageBatchRequestEntry, 0, 10)
 
@@ -48,7 +49,11 @@ func (sc *SqsClient) PublishToQueue(height int64, data []*types.Message) error {
 			MessageAttributes: map[string]*sqs.MessageAttributeValue{
 				"height": {
 					DataType:    aws.String("Number"),
-					StringValue: aws.String(strconv.FormatInt(height, 10)),
+					StringValue: aws.String(strconv.FormatInt(message.Block.Height, 10)),
+				},
+				"time": {
+					DataType:    aws.String("String"),
+					StringValue: aws.String(message.Block.Time.Format(time.RFC3339)),
 				},
 			},
 			MessageBody: aws.String(string(serialisedMessage)),

--- a/plugins/indexing/types/block_context.go
+++ b/plugins/indexing/types/block_context.go
@@ -1,0 +1,15 @@
+package types
+
+import "time"
+
+type BlockContext struct {
+	Height int64
+	Time   time.Time
+}
+
+func NewBlockContext(height int64, timestamp time.Time) *BlockContext {
+	return &BlockContext{
+		Height: height,
+		Time:   timestamp,
+	}
+}

--- a/plugins/indexing/types/message.go
+++ b/plugins/indexing/types/message.go
@@ -1,13 +1,15 @@
 package types
 
 type Message struct {
-	Type string      `json:"type"`
-	Data interface{} `json:"data"`
+	Block *BlockContext `json:"-"`
+	Type  string        `json:"type"`
+	Data  interface{}   `json:"data"`
 }
 
-func NewMessage(messageType string, data interface{}) *Message {
+func NewMessage(messageType string, data interface{}, block *BlockContext) *Message {
 	return &Message{
-		Type: messageType,
-		Data: data,
+		Block: block,
+		Type:  messageType,
+		Data:  data,
 	}
 }


### PR DESCRIPTION
## Explanation of Changes

Also refactor SQS publishing to allow messages to carry the associated block height and time.

## Testing

Run the chain and plugin locally and verify the messages on the queue have the correct attributes:

```sh
aws --endpoint-url http://localhost:4100 sqs receive-message --queue-url http://localhost:4100/local-updates.fifo --attribute-names height,time
{
    "Messages": [
        {
            "MessageId": "3e9eb3a0-7030-47f0-961e-745e6d8a5583",
            "ReceiptHandle": "3e9eb3a0-7030-47f0-961e-745e6d8a5583#8921b4ff-5b42-40ef-b404-07d31e2ce536",
            "MD5OfBody": "e88e931a689f0ee2939ab27c3dc51f4f",
            "Body": "{\"type\":\"block\",\"data\":{\"hash\":\"8223F5B02B59C3BE888C215CB1FA0BDA3B2194E873BD9B74A4BED6B51A5489FC\",\"time\":\"2024-04-10T19:35:15.116228Z\",\"txCount\":0,\"proposerAddress\":\"sedavalcons1gnl65ayhvetqjm42ynxwlkv7g93w0h4a5rvuuc\"}}",
            "Attributes": {
                "ApproximateFirstReceiveTimestamp": "1712777747974",
                "SenderId": "queue",
                "ApproximateReceiveCount": "1",
                "SentTimestamp": "1712777747974"
            },
            "MD5OfMessageAttributes": "a868437a6f954843ba5af790a36bc7d4",
            "MessageAttributes": {
                "height": {
                    "StringValue": "1",
                    "DataType": "Number"
                },
                "time": {
                    "StringValue": "2024-04-10T19:35:15Z",
                    "DataType": "String"
                }
            }
        }
    ]
}
```

## Related PRs and Issues

Closes: #242
Spawns: https://github.com/sedaprotocol/seda-explorer/issues/246
