### PR TITLE
Correctly format balance updates with 0aseda

### DIFF
--- a/plugins/indexing/bank/module.go
+++ b/plugins/indexing/bank/module.go
@@ -45,9 +45,13 @@ func ExtractUpdate(ctx *types.BlockContext, _ codec.Codec, logger *log.Logger, c
 		}
 
 		var balance math.Int
-		err = balance.Unmarshal(change.Value)
-		if err != nil {
-			return nil, err
+		if change.Delete {
+			balance = math.ZeroInt()
+		} else {
+			err = balance.Unmarshal(change.Value)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		data := struct {


### PR DESCRIPTION
## Motivation

Since these entries just get deleted from the store we have to manually set the published amount to 0.

## Testing

I added a genesis account with `20000000000000001aseda` as balance and then delegated `1aseda` to the local validator with a fee of `20000000000000000aseda`, which leaves the account with `0aseda` as balance.

Observing the log output and published messages when running locally:

Log before:
```
2024-04-11T13:40:00.720+0200 [DEBUG] Extracted update: message="&{0x1400065e400 account-balance {seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah <nil> aseda}}"
```

Log after:
```
2024-04-11T13:32:32.354+0200 [DEBUG] Extracted update: message="&{0x14000f318e0 account-balance {seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah 0 aseda}}"
```

Queu message before:
```json
{
  "type": "account-balance",
  "data": {
    "address": "seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah",
    "balance": "\\u003cnil\\u003e",
    "denom": "aseda"
  }
}

```

Queue message after:
```json
{
  "type": "account-balance",
  "data": {
    "address": "seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah",
    "balance": "0",
    "denom": "aseda"
  }
}

```

## Related PRs and Issues

N.A.
