### PR TITLE
feat(plugin): publish block event data

### DIFF
--- a/plugins/indexing/base/block.go
+++ b/plugins/indexing/base/block.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
 )
 
-func ExtractBlockUpdate(ctx *types.BlockContext, req abci.RequestFinalizeBlock) (*types.Message, error) {
+func ExtractBlockUpdate(ctx *types.BlockContext, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) (*types.Message, error) {
 	hash := strings.ToUpper(hex.EncodeToString(req.Hash))
 	txCount := len(req.Txs)
 	proposerAddress, err := sdk.ConsAddressFromHex(hex.EncodeToString(req.ProposerAddress))
@@ -20,15 +20,17 @@ func ExtractBlockUpdate(ctx *types.BlockContext, req abci.RequestFinalizeBlock) 
 	}
 
 	data := struct {
-		Hash            string    `json:"hash"`
-		Time            time.Time `json:"time"`
-		TxCount         int       `json:"txCount"`
-		ProposerAddress string    `json:"proposerAddress"`
+		Hash            string       `json:"hash"`
+		Time            time.Time    `json:"time"`
+		TxCount         int          `json:"txCount"`
+		ProposerAddress string       `json:"proposerAddress"`
+		Events          []abci.Event `json:"events"`
 	}{
 		Hash:            hash,
 		Time:            req.Time,
 		TxCount:         txCount,
 		ProposerAddress: proposerAddress.String(),
+		Events:          res.Events,
 	}
 
 	return types.NewMessage("block", data, ctx), nil

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -56,7 +56,7 @@ func (p *IndexerPlugin) ListenFinalizeBlock(_ context.Context, req abci.RequestF
 	// TODO(#229) Change to +2 to account for the votes message
 	messages := make([]*types.Message, 0, len(req.Txs)+1)
 
-	blockMessage, err := base.ExtractBlockUpdate(p.block, req)
+	blockMessage, err := base.ExtractBlockUpdate(p.block, req, res)
 	if err != nil {
 		p.logger.Error("Failed to extract block update", "error", err)
 		return err


### PR DESCRIPTION
## Motivation

Enable the indexer to add events to a block which will ultimately allow the frontend to display these to the user.

## Explanation of Changes

N.A.

## Testing

I tried submitting a bunch of different transactions (CosmWasm code upload, transfers, create validator) and none of the TX events also showed up in the block events output as expected.

Running the chain and plugin locally you can see that the events are now part of the serialised message on the queue:

```json
{
  "type": "block",
  "data": {
    "hash": "6B0E2CBB389B276049E5AF9C5D2EC248756B699507643157B8A093F1A1020D2E",
    "time": "2024-05-02T09:38:17.150989Z",
    "txCount": 1,
    "proposerAddress": "sedavalcons1gapnqg6u8wkjm3et7qd3j8l3vkftukt52qfjmg",
    "events": [
      {
        "type": "coin_received",
        "attributes": [
          {
            "key": "receiver",
            "value": "seda1m3h30wlvsf8llruxtpukdvsy0km2kum87ltqyp",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "coinbase",
        "attributes": [
          {
            "key": "minter",
            "value": "seda1m3h30wlvsf8llruxtpukdvsy0km2kum87ltqyp",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "coin_spent",
        "attributes": [
          {
            "key": "spender",
            "value": "seda1m3h30wlvsf8llruxtpukdvsy0km2kum87ltqyp",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "coin_received",
        "attributes": [
          {
            "key": "receiver",
            "value": "seda17xpfvakm2amg962yls6f84z3kell8c5lxh0cgu",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "transfer",
        "attributes": [
          {
            "key": "recipient",
            "value": "seda17xpfvakm2amg962yls6f84z3kell8c5lxh0cgu",
            "index": true
          },
          {
            "key": "sender",
            "value": "seda1m3h30wlvsf8llruxtpukdvsy0km2kum87ltqyp",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "message",
        "attributes": [
          {
            "key": "sender",
            "value": "seda1m3h30wlvsf8llruxtpukdvsy0km2kum87ltqyp",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "mint",
        "attributes": [
          {
            "key": "bonded_ratio",
            "value": "0.019999996292491258",
            "index": true
          },
          {
            "key": "inflation",
            "value": "0.130000199824136413",
            "index": true
          },
          {
            "key": "annual_provisions",
            "value": "65000111961492372386290931579613226.097983536356403813",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "coin_spent",
        "attributes": [
          {
            "key": "spender",
            "value": "seda17xpfvakm2amg962yls6f84z3kell8c5lxh0cgu",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "coin_received",
        "attributes": [
          {
            "key": "receiver",
            "value": "seda1jv65s3grqf6v6jl3dp4t6c9t9rk99cd833gy27",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "transfer",
        "attributes": [
          {
            "key": "recipient",
            "value": "seda1jv65s3grqf6v6jl3dp4t6c9t9rk99cd833gy27",
            "index": true
          },
          {
            "key": "sender",
            "value": "seda17xpfvakm2amg962yls6f84z3kell8c5lxh0cgu",
            "index": true
          },
          {
            "key": "amount",
            "value": "10298646278787419256580179034aseda",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "message",
        "attributes": [
          {
            "key": "sender",
            "value": "seda17xpfvakm2amg962yls6f84z3kell8c5lxh0cgu",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "commission",
        "attributes": [
          {
            "key": "amount",
            "value": "1009267335321167087144857545.332000000000000000aseda",
            "index": true
          },
          {
            "key": "validator",
            "value": "sedavaloper1k5k74jhfyk7ckefyhsn2cvjf08r65fctdvlkhk",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      },
      {
        "type": "rewards",
        "attributes": [
          {
            "key": "amount",
            "value": "10092673353211670871448575453.320000000000000000aseda",
            "index": true
          },
          {
            "key": "validator",
            "value": "sedavaloper1k5k74jhfyk7ckefyhsn2cvjf08r65fctdvlkhk",
            "index": true
          },
          { "key": "mode", "value": "BeginBlock", "index": true }
        ]
      }
    ]
  }
}
```

## Related PRs and Issues

Closes: #257
