### PR TITLE
Add message filtering capability

### DIFF
--- a/plugins/indexing/README.md
+++ b/plugins/indexing/README.md
@@ -17,6 +17,9 @@ export S3_LARGE_MSG_BUCKET_NAME=""
 export PLUGIN_LOG_FILE=PATH_TO_DESIRED_LOG_FILE
 # Optionally you can also specify the log level, one of "trace", "debug", "info", "warn", "error"
 export PLUGIN_LOG_LEVEL="WARN"
+# Optionally you can specifiy a comma separated list of event types which are allowed to be published on the queue.
+# When omitted it will default to publishing all message types.
+export ALLOWED_MESSAGE_TYPES="block,account"
 ```
 
 Lastly, as we're using SQS and S3 the node needs access to a valid set of AWS credentials with permission to publish messages to the specified queue and upload access to the specified bucket.

--- a/plugins/indexing/pluginaws/message_filter.go
+++ b/plugins/indexing/pluginaws/message_filter.go
@@ -1,0 +1,30 @@
+package pluginaws
+
+import (
+	"slices"
+
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+)
+
+func (sc *SqsClient) filterMessages(data []*types.Message) []*types.Message {
+	allowedMessages := make([]*types.Message, 0, len(data))
+
+	for _, message := range data {
+		if sc.isMessageAllowed(message) {
+			allowedMessages = append(allowedMessages, message)
+		} else {
+			sc.logger.Trace("skipping message", "type", message.Type)
+		}
+	}
+
+	return allowedMessages
+}
+
+func (sc *SqsClient) isMessageAllowed(event *types.Message) bool {
+	// When no allowlist is specified assume everything is allowed.
+	if len(sc.allowedMessages) == 0 {
+		return true
+	}
+
+	return slices.Contains(sc.allowedMessages, event.Type)
+}

--- a/plugins/indexing/pluginaws/sqs_client.go
+++ b/plugins/indexing/pluginaws/sqs_client.go
@@ -16,7 +16,8 @@ const (
 func (sc *SqsClient) PublishToQueue(data []*types.Message) error {
 	sc.logger.Trace("publishing to queue", "size", len(data))
 
-	sizedBatchEntries, err := sc.createSizedBatchEntries(data)
+	allowedMessages := sc.filterMessages(data)
+	sizedBatchEntries, err := sc.createSizedBatchEntries(allowedMessages)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Motivation

Make indexing previously indexed state easier by skipping messages that have already been indexed.

## Explanation of Changes

Optionally allow configuring a list of message types that are allowed to be published on the queue. Went for an allowlist as we'll generally use it when we want to reindex historical state and only publish updates for the new messages.

For the same reason I went for a simple slice of strings as the data structure; the list should never be long enough to matter in terms of performance.

## Testing

Ran a local chain with the messages allowlist attribute set to `account,account-balance`

Logs:
```log
2024-05-15T18:00:34.456+0800 [TRACE] publishing to queue: size=4
2024-05-15T18:00:34.456+0800 [TRACE] skipping message: type=supply
2024-05-15T18:00:34.456+0800 [TRACE] sending batch: size=3
```

And on the queue side we only received the account and account balance updates.

## Related PRs and Issues

Closes: #258
