### PR TITLE
Add retry to S3 connection reset errors

### DIFF
--- a/plugins/indexing/pluginaws/aws_session.go
+++ b/plugins/indexing/pluginaws/aws_session.go
@@ -4,6 +4,8 @@ package pluginaws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -14,5 +16,13 @@ func NewSession() (*session.Session, error) {
 }
 
 func NewS3Config() (*aws.Config, error) {
-	return aws.NewConfig(), nil
+	cfg := aws.NewConfig()
+	request.WithRetryer(cfg, CustomRetryer{DefaultRetryer: client.DefaultRetryer{
+		NumMaxRetries:    client.DefaultRetryerMaxNumRetries,
+		MinRetryDelay:    client.DefaultRetryerMinRetryDelay,
+		MaxRetryDelay:    client.DefaultRetryerMaxRetryDelay,
+		MinThrottleDelay: client.DefaultRetryerMinThrottleDelay,
+		MaxThrottleDelay: client.DefaultRetryerMaxThrottleDelay,
+	}})
+	return cfg, nil
 }

--- a/plugins/indexing/pluginaws/custom_retryer.go
+++ b/plugins/indexing/pluginaws/custom_retryer.go
@@ -1,0 +1,30 @@
+package pluginaws
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+type CustomRetryer struct {
+	client.DefaultRetryer
+}
+
+func (r CustomRetryer) MaxRetries() int {
+	return r.DefaultRetryer.MaxRetries()
+}
+
+func (r CustomRetryer) RetryRules(req *request.Request) time.Duration {
+	return r.DefaultRetryer.RetryRules(req)
+}
+
+func (r CustomRetryer) ShouldRetry(req *request.Request) bool {
+	if strings.Contains(req.Error.Error(), "read: connection reset") {
+		return true
+	}
+
+	// Fallback to SDK's built in retry rules
+	return r.DefaultRetryer.ShouldRetry(req)
+}


### PR DESCRIPTION
## Motivation

Every once in a while the indexing plugin receives a connection rest while attempting to upload a large message to S3. This halts the indexing process as there are some cases where an error in the indexer warrants a reset to the previous block. By default the retry logic from the AWS SDK does not retry on connection resets as it can't know whether the request that was made is idempotent or not.

## Explanation of Changes

Based on some reading:
PR trying to 'fix' that the SDK no longer retries connection reset errors: https://github.com/aws/aws-sdk-go/pull/2926
How to determine the error: https://github.com/aws/aws-sdk-go/blob/v1.44.224/aws/request/connection_reset_error.go
Custom retryer example: https://github.com/aws/aws-sdk-go/blob/main/example/aws/request/customRetryer/custom_retryer.go

Since we know that the upload action is idempotent we can safely configure the retry SDK to retry connection reset errors.

## Testing

Not entirely sure how to test this. At least it still works for the normal flow.

## Related PRs and Issues

Closes: #273

