### PR TITLE
Publish staking module messages

### DIFF
--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/base"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/pluginaws"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/staking"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
 )
 
@@ -85,6 +86,8 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 		return bank.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case auth.StoreKey:
 		return auth.ExtractUpdate(p.block, p.cdc, p.logger, change)
+	case staking.StoreKey:
+		return staking.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	default:
 		return nil, nil
 	}

--- a/plugins/indexing/staking/module.go
+++ b/plugins/indexing/staking/module.go
@@ -1,0 +1,160 @@
+package staking
+
+import (
+	"bytes"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	gogotypes "github.com/cosmos/gogoproto/types"
+
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+)
+
+const StoreKey = stakingtypes.StoreKey
+
+type wrappedValidator struct {
+	cdc       codec.Codec
+	Validator stakingtypes.Validator
+}
+
+func (s wrappedValidator) MarshalJSON() ([]byte, error) {
+	return s.cdc.MarshalJSON(&s.Validator)
+}
+
+func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+	if _, found := bytes.CutPrefix(change.Key, stakingtypes.ParamsKey); found {
+		val, err := codec.CollValue[stakingtypes.Params](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ModuleName string              `json:"moduleName"`
+			Params     stakingtypes.Params `json:"params"`
+		}{
+			ModuleName: "staking",
+			Params:     val,
+		}
+
+		return types.NewMessage("module-params", data, ctx), nil
+	} else if _, found := bytes.CutPrefix(change.Key, stakingtypes.LastTotalPowerKey); found {
+		power := sdk.IntProto{}
+		err := cdc.Unmarshal(change.Value, &power)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			Power string `json:"power"`
+		}{
+			Power: power.Int.String(),
+		}
+
+		return types.NewMessage("total-power", data, ctx), nil
+	} else if keyBytes, found := bytes.CutPrefix(change.Key, stakingtypes.LastValidatorPowerKey); found {
+		_, key, err := sdk.ValAddressKey.Decode(keyBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		val, err := codec.CollValue[gogotypes.Int64Value](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ValidatorAddress string `json:"validatorAddress"`
+			Power            int64  `json:"power"`
+		}{
+			ValidatorAddress: key.String(),
+			Power:            val.Value,
+		}
+
+		return types.NewMessage("validator-power", data, ctx), nil
+	} else if _, found := bytes.CutPrefix(change.Key, stakingtypes.ValidatorsKey); found {
+		val, err := codec.CollValue[stakingtypes.Validator](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return types.NewMessage("validator", &wrappedValidator{cdc: cdc, Validator: val}, ctx), nil
+	} else if keyBytes, found := bytes.CutPrefix(change.Key, stakingtypes.DelegationKey); found {
+		if change.Delete {
+			// The value of the delete change does not include the delegator nor the validator address.
+			_, key, err := collections.PairKeyCodec(sdk.AccAddressKey, sdk.ValAddressKey).Decode(keyBytes)
+			if err != nil {
+				return nil, err
+			}
+
+			data := stakingtypes.Delegation{
+				DelegatorAddress: key.K1().String(),
+				ValidatorAddress: key.K2().String(),
+				Shares:           math.LegacyZeroDec(),
+			}
+
+			return types.NewMessage("delegation", data, ctx), nil
+		}
+
+		val, err := codec.CollValue[stakingtypes.Delegation](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return types.NewMessage("delegation", val, ctx), nil
+	} else if keyBytes, found := bytes.CutPrefix(change.Key, stakingtypes.UnbondingDelegationKey); found {
+		if change.Delete {
+			// The value of the delete change does not include the delegator nor the validator address.
+			_, key, err := collections.PairKeyCodec(sdk.AccAddressKey, sdk.ValAddressKey).Decode(keyBytes)
+			if err != nil {
+				return nil, err
+			}
+
+			data := stakingtypes.UnbondingDelegation{
+				DelegatorAddress: key.K1().String(),
+				ValidatorAddress: key.K2().String(),
+				Entries:          nil,
+			}
+
+			return types.NewMessage("unbonding-delegation", data, ctx), nil
+		}
+
+		val, err := codec.CollValue[stakingtypes.UnbondingDelegation](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return types.NewMessage("unbonding-delegation", val, ctx), nil
+	} else if keyBytes, found := bytes.CutPrefix(change.Key, stakingtypes.RedelegationKey); found {
+		if change.Delete {
+			// The value of the delete change does not include the delegator nor the validator addresses.
+			_, key, err := collections.TripleKeyCodec(sdk.AccAddressKey, sdk.ValAddressKey, sdk.ValAddressKey).Decode(keyBytes)
+			if err != nil {
+				return nil, err
+			}
+
+			data := stakingtypes.Redelegation{
+				DelegatorAddress:    key.K1().String(),
+				ValidatorSrcAddress: key.K2().String(),
+				ValidatorDstAddress: key.K3().String(),
+				Entries:             nil,
+			}
+
+			return types.NewMessage("redelegation", data, ctx), nil
+		}
+
+		val, err := codec.CollValue[stakingtypes.Redelegation](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		return types.NewMessage("redelegation", val, ctx), nil
+	}
+
+	logger.Trace("skipping change", "change", change)
+	return nil, nil
+}


### PR DESCRIPTION
## Motivation

This includes messages for the validator information, power, delegations, unbonding delegations, redelegations, and staking module parameters.

## Explanation of Changes

Reasonably straightforward code. The delete entry for some values requires us to process the event differently, but even that is not too fancy.

## Testing

Running a local chain with the following changes to the genesis to facilitate testing:

```sh
cat $HOME/.sedad/config/genesis.json | jq '.app_state["staking"]["params"]["unbonding_time"]="30s"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
cat $HOME/.sedad/config/genesis.json | jq '.app_state["slashing"]["params"]["signed_blocks_window"]="30"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
```

Tested the following scenarios:
- Create validator, delegate enough to bond the validator, unbond enough to unbond the validator.
- Create validator, delegate enough to bond the validator, unbond a little, redelegate a little, let the new validator be slashed for missing blocks.
- Create validator, delegate, delegate again.
- Create validator, delegate enough to bond validator, unbond a little, unbond a little, unbond a little, let the unbondings expire.
- Create validator, delegate enough to bond validator, redelegate a little, redelegate a little, redelegate a little, let the redelegations expire.
- Create validator, edit validator.

The JSON payloads for all message types:

```ts
export default {
  type: "validator",
  data: {
    operator_address: "sedavaloper16a04nlmf0gqqkrn5qmxajgs6lyrz2cg6gfw2hd",
    consensus_pubkey: {
      "@type": "/cosmos.crypto.ed25519.PubKey",
      key: "jocaaGL8G7iOPnoMEZleoKhOKvkiHFQNcxVzsFkU8Jk=",
    },
    jailed: false,
    status: "BOND_STATUS_BONDED",
    tokens: "10000000000000000000000000000000000",
    delegator_shares: "10000000000000000000000000000000000.000000000000000000",
    description: {
      moniker: "node0",
      identity: "",
      website: "",
      security_contact: "",
      details: "",
    },
    unbonding_height: "0",
    unbonding_time: "1970-01-01T00:00:00Z",
    commission: {
      commission_rates: {
        rate: "0.100000000000000000",
        max_rate: "0.200000000000000000",
        max_change_rate: "0.010000000000000000",
      },
      update_time: "2024-05-17T11:23:53.899900Z",
    },
    min_self_delegation: "1",
    unbonding_on_hold_ref_count: "0",
    unbonding_ids: [],
  },
};
```

```ts
export default {
  type: 'delegation',
  data: {
    delegator_address: 'seda1rq8q34238p7vftat2h487edcqnt2uyz8ye6f3t',
    validator_address: 'sedavaloper1rq8q34238p7vftat2h487edcqnt2uyz800zj2j',
    shares: '10000000000000000000000000000000000.000000000000000000',
  },
};
```

```ts
export default {
  type: 'redelegation',
  data: {
    delegator_address: 'seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah',
    validator_src_address: 'sedavaloper16ezzvedt6w36md3caddhsxkf4rx7jjajay2afl',
    validator_dst_address: 'sedavaloper12rype4zl8wxcgqwl237fll6hvufkgcj8act8xw',
    entries: [
      {
        creation_height: 31,
        completion_time: '2024-05-27T06:08:42.879729Z',
        initial_balance: '10',
        shares_dst: '10.000000000000000000',
        unbonding_id: 1,
      },
    ],
  },
};
```

```ts
export default {
  type: 'unbonding-delegation',
  data: {
    delegator_address: 'seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah',
    validator_address: 'sedavaloper1hz4ptpsk2a2uevxj65mzuunymkv629j5645gk6',
    entries: [
      {
        creation_height: 6,
        completion_time: '2024-05-27T05:32:32.097965Z',
        initial_balance: '1',
        balance: '1',
        unbonding_id: 1,
      },
    ],
  },
};
```

```ts
export default {
  type: "validator-power",
  data: {
    validatorAddress: "sedavaloper1s32076qmc337j3jpe7n729vh4clru5556ykzhv",
    power: 100000000000000000
  }
};
```

```ts
export default { type: "total-power", data: { power: "100000000000000000" } };
```

```ts
export default {
  type: 'module-params',
  data: {
    moduleName: 'staking',
    params: {
      unbonding_time: 1814400000000000,
      max_validators: 100,
      max_entries: 7,
      historical_entries: 10000,
      bond_denom: 'aseda',
      min_commission_rate: '0.000000000000000000',
    },
  },
};
```

## Related PRs and Issues

Closes: #270

