### PR TITLE
fix: fix empty event bug from wasm-storage module

### DIFF
--- a/x/wasm-storage/keeper/msg_server.go
+++ b/x/wasm-storage/keeper/msg_server.go
@@ -93,13 +93,12 @@ func (m msgServer) StoreDataRequestWasm(goCtx context.Context, msg *types.MsgSto
 
 	hashString := hex.EncodeToString(wasm.Hash)
 	err = ctx.EventManager().EmitTypedEvent(
-		&EventStoreDataRequestWasmWrapper{
-			EventStoreDataRequestWasm: &types.EventStoreDataRequestWasm{
-				Hash:     hashString,
-				WasmType: msg.WasmType,
-				Bytecode: msg.Wasm,
-			},
-		})
+		&types.EventStoreDataRequestWasm{
+			Hash:     hashString,
+			WasmType: msg.WasmType,
+			Bytecode: msg.Wasm,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -138,13 +137,12 @@ func (m msgServer) StoreOverlayWasm(goCtx context.Context, msg *types.MsgStoreOv
 
 	hashString := hex.EncodeToString(wasm.Hash)
 	err = ctx.EventManager().EmitTypedEvent(
-		&EventStoreOverlayWasmWrapper{
-			EventStoreOverlayWasm: &types.EventStoreOverlayWasm{
-				Hash:     hashString,
-				WasmType: msg.WasmType,
-				Bytecode: msg.Wasm,
-			},
-		})
+		&types.EventStoreOverlayWasm{
+			Hash:     hashString,
+			WasmType: msg.WasmType,
+			Bytecode: msg.Wasm,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Explanation of Changes
- Removed `EventStoreDataRequestWasmWrapper` and `EventStoreOverlayWasmWrapper` wrappers for emitting events
- Directly using `EventStoreDataRequestWasm` and `EventStoreOverlayWasm` proto event messages fixes the issue


Closes: #303
