### PR TITLE
Move to regular queue

### DIFF
--- a/plugins/indexing/README.md
+++ b/plugins/indexing/README.md
@@ -122,7 +122,7 @@ To simplify local development we use [a SQS emulator](https://github.com/Admiral
 
 ```sh
 # Example urls
-export SQS_QUEUE_URL=http://localhost/4100/test-queue.fifo
+export SQS_QUEUE_URL=http://localhost/4100/test-queue
 export SQS_ENDPOINT=http://localhost:4100
 export S3_LARGE_MSG_BUCKET_NAME="indexer-localnet-large-messages"
 export S3_ENDPOINT=http://localhost:9444

--- a/plugins/indexing/pluginaws/sized_batch_entry.go
+++ b/plugins/indexing/pluginaws/sized_batch_entry.go
@@ -70,7 +70,6 @@ func (sc *SqsClient) createSizedBatchEntries(data []*types.Message) ([]*sizedBat
 
 		sizedEntry, err := newSizedBatchEntry(&sqs.SendMessageBatchRequestEntry{
 			Id:                aws.String(fmt.Sprintf("%s-%d", message.Type, i)),
-			MessageGroupId:    aws.String("chain_events"),
 			MessageAttributes: attributes,
 			MessageBody:       aws.String(string(serialisedMessage)),
 		})


### PR DESCRIPTION
## Motivation

Reduce costs, simplify implementation, easier error handling.

## Explanation of Changes

Essentially did the reverse of the AWS instructions for moving to a FIFO queue: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-moving.html

## Testing

Ran the chain + plugin locally and confirmed the messages still end up in the local queue emulator.

## Related PRs and Issues

Closes: #233
