### PR TITLE
fix: Adding build tag for Rosetta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifeq (rocksdb,$(findstring rocksdb,$(COSMOS_BUILD_OPTIONS)))
   endif
 endif
 
-# Rosetta
+# Rosetta support
 ifeq ($(ENABLE_ROSETTA),true)
   BUILD_TAGS += rosetta
 endif

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,10 @@ endif
 
 # For building statically linked binaries
 ifeq ($(LINK_STATICALLY),true)
-	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
+  ifeq ($(ENABLE_ROSETTA),true)
+    $(error Cannot link statically when Rosetta is enabled)
+  endif
+  ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
 endif
 
 ifeq (,$(findstring nostrip,$(COSMOS_BUILD_OPTIONS)))

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ ifeq (rocksdb,$(findstring rocksdb,$(COSMOS_BUILD_OPTIONS)))
   endif
 endif
 
+# Rosetta
+ifeq ($(ENABLE_ROSETTA),true)
+  BUILD_TAGS += rosetta
+endif
+
 # For building statically linked binaries
 ifeq ($(LINK_STATICALLY),true)
 	ldflags += -linkmode=external -extldflags "-Wl,-z,muldefs -static"

--- a/cmd/sedad/cmd/root.go
+++ b/cmd/sedad/cmd/root.go
@@ -142,9 +142,6 @@ func NewRootCmd() *cobra.Command {
 
 	initRootCmd(rootCmd, encodingConfig, tempApp.BasicModuleManager())
 	addRosettaCmd(rootCmd, encodingConfig)
-	// rootCmd.AddCommand(
-	// 	rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler),
-	// )
 
 	autoCliOpts := tempApp.AutoCliOpts()
 	initClientCtx, _ = config.ReadFromClientConfig(initClientCtx)

--- a/cmd/sedad/cmd/root.go
+++ b/cmd/sedad/cmd/root.go
@@ -15,7 +15,6 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	confixcmd "cosmossdk.io/tools/confix/cmd"
 	tmcli "github.com/cometbft/cometbft/libs/cli"
-	rosettaCmd "github.com/cosmos/rosetta/cmd"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -142,9 +141,10 @@ func NewRootCmd() *cobra.Command {
 	}
 
 	initRootCmd(rootCmd, encodingConfig, tempApp.BasicModuleManager())
-	rootCmd.AddCommand(
-		rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler),
-	)
+	addRosettaCmd(rootCmd, encodingConfig)
+	// rootCmd.AddCommand(
+	// 	rosettaCmd.RosettaCommand(encodingConfig.InterfaceRegistry, encodingConfig.Marshaler),
+	// )
 
 	autoCliOpts := tempApp.AutoCliOpts()
 	initClientCtx, _ = config.ReadFromClientConfig(initClientCtx)

--- a/cmd/sedad/cmd/rosetta_disabled.go
+++ b/cmd/sedad/cmd/rosetta_disabled.go
@@ -1,0 +1,11 @@
+//go:build !rosetta
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sedaprotocol/seda-chain/app"
+)
+
+func addRosettaCmd(_ *cobra.Command, _ app.EncodingConfig) {}

--- a/cmd/sedad/cmd/rosetta_enabled.go
+++ b/cmd/sedad/cmd/rosetta_enabled.go
@@ -1,0 +1,14 @@
+//go:build rosetta
+
+package cmd
+
+import (
+	rosettaCmd "github.com/cosmos/rosetta/cmd"
+	"github.com/spf13/cobra"
+
+	"github.com/sedaprotocol/seda-chain/app"
+)
+
+func addRosettaCmd(cmd *cobra.Command, encodingCfg app.EncodingConfig) {
+	cmd.AddCommand(rosettaCmd.RosettaCommand(encodingCfg.InterfaceRegistry, encodingCfg.Marshaler))
+}


### PR DESCRIPTION
## Motivation

Adding an optional build tag called `rosetta` to determine whether to add Rosetta support or not.
To build with this tag using make, run:
```
ENABLE_ROSETTA=true make build
```

Related: #298 
Thank you @Thomasvdam for the solution!