### PR TITLE
chore(data-proxy): update proxy query not found error

### DIFF
--- a/x/data-proxy/keeper/common_test.go
+++ b/x/data-proxy/keeper/common_test.go
@@ -3,7 +3,10 @@ package keeper_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	storetypes "cosmossdk.io/store/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/runtime"
@@ -12,7 +15,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	"github.com/stretchr/testify/suite"
 
 	"github.com/sedaprotocol/seda-chain/app/params"
 	dataproxy "github.com/sedaprotocol/seda-chain/x/data-proxy"

--- a/x/data-proxy/keeper/grpc_query.go
+++ b/x/data-proxy/keeper/grpc_query.go
@@ -2,6 +2,9 @@ package keeper
 
 import (
 	"context"
+	"errors"
+
+	"cosmossdk.io/collections"
 
 	"github.com/sedaprotocol/seda-chain/x/data-proxy/types"
 )
@@ -15,7 +18,12 @@ type Querier struct {
 func (q Querier) DataProxyConfig(ctx context.Context, req *types.QueryDataProxyConfigRequest) (*types.QueryDataProxyConfigResponse, error) {
 	result, err := q.GetDataProxyConfig(ctx, req.PubKey)
 	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, types.ErrUnknownDataProxy.Wrapf("no data proxy registered for %s", req.PubKey)
+		}
+
 		return nil, err
 	}
+
 	return &types.QueryDataProxyConfigResponse{Config: &result}, nil
 }

--- a/x/data-proxy/keeper/grpc_query_test.go
+++ b/x/data-proxy/keeper/grpc_query_test.go
@@ -1,5 +1,78 @@
 package keeper_test
 
+import (
+	"encoding/hex"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/sedaprotocol/seda-chain/x/data-proxy/types"
+)
+
 func (s *KeeperTestSuite) TestQuerier_ProxyConfig() {
-	// TODO
+	tests := []struct {
+		name      string
+		config    *types.ProxyConfig
+		pubKeyHex string
+		wantErr   error
+	}{
+		{
+			name: "Simple proxy",
+			config: &types.ProxyConfig{
+				AdminAddress:  "admin",
+				PayoutAddress: "pay",
+				Fee:           &sdk.Coin{Denom: "aseda", Amount: math.NewInt(5)},
+				Memo:          "",
+				FeeUpdate:     nil,
+			},
+			pubKeyHex: "02100efce2a783cc7a3fbf9c5d15d4cc6e263337651312f21a35d30c16cb38f4c3",
+			wantErr:   nil,
+		},
+		{
+			name: "Proxy with pending update",
+			config: &types.ProxyConfig{
+				AdminAddress:  "admin",
+				PayoutAddress: "pay",
+				Fee:           &sdk.Coin{Denom: "aseda", Amount: math.NewInt(5)},
+				Memo:          "",
+				FeeUpdate: &types.FeeUpdate{
+					NewFee:       sdk.Coin{Denom: "aseda", Amount: math.NewInt(10)},
+					UpdateHeight: 6,
+				},
+			},
+			pubKeyHex: "02100efce2a783cc7a3fbf9c5d15d4cc6e263337651312f21a35d30c16cb38f4c3",
+			wantErr:   nil,
+		},
+		{
+			name:      "Unknown pubkey",
+			config:    nil,
+			pubKeyHex: "02100efce2a783cc7a3fbf9c5d15d4cc6e263337651312f21a35d30c16cb38f4c3",
+			wantErr:   types.ErrUnknownDataProxy,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			s.SetupTest()
+
+			if tt.config != nil {
+				pubkeyBytes, err := hex.DecodeString(tt.pubKeyHex)
+				s.Require().NoError(err)
+
+				err = s.keeper.DataProxyConfigs.Set(s.ctx, pubkeyBytes, *tt.config)
+				s.Require().NoError(err)
+			}
+
+			res, err := s.queryClient.DataProxyConfig(s.ctx, &types.QueryDataProxyConfigRequest{PubKey: "02100efce2a783cc7a3fbf9c5d15d4cc6e263337651312f21a35d30c16cb38f4c3"})
+			if tt.wantErr != nil {
+				s.Require().ErrorIs(err, tt.wantErr)
+				s.Require().Nil(res)
+				return
+			}
+			s.Require().NoError(err)
+			s.Require().NotNil(res)
+			s.Require().Equal(tt.config, res.Config)
+		})
+	}
 }

--- a/x/data-proxy/keeper/keeper.go
+++ b/x/data-proxy/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 
 	"cosmossdk.io/collections"
 	storetypes "cosmossdk.io/core/store"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 
 	"github.com/sedaprotocol/seda-chain/x/data-proxy/types"

--- a/x/data-proxy/keeper/msg_server_test.go
+++ b/x/data-proxy/keeper/msg_server_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/sedaprotocol/seda-chain/x/data-proxy/types"

--- a/x/data-proxy/module.go
+++ b/x/data-proxy/module.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"cosmossdk.io/core/appmodule"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"

--- a/x/data-proxy/types/errors.go
+++ b/x/data-proxy/types/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrInvalidSignature = errors.Register(ModuleName, 4, "invalid signature")
 	ErrInvalidAddress   = errors.Register(ModuleName, 5, "invalid address")
 	ErrInvalidHex       = errors.Register(ModuleName, 6, "invalid hex string")
+	ErrUnknownDataProxy = errors.Register(ModuleName, 7, "unknown public key")
 )


### PR DESCRIPTION
## Motivation

Give the user better feedback when a public key does not have an associated data proxy config registered.

## Explanation of Changes

Not much, just updating what was already there from the boilerplate, adding tests, and making the error a little more user friendly when an unknown public key is queried.

## Testing

Added tests for the query server.

## Related PRs and Issues

Part-of: #316
