### PR TITLE
Emit data-proxy events

### DIFF
--- a/x/data-proxy/keeper/abci.go
+++ b/x/data-proxy/keeper/abci.go
@@ -1,9 +1,13 @@
 package keeper
 
 import (
+	"encoding/hex"
+
 	"cosmossdk.io/collections"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/sedaprotocol/seda-chain/x/data-proxy/types"
 )
 
 func (k *Keeper) EndBlock(ctx sdk.Context) (err error) {
@@ -48,7 +52,10 @@ func (k *Keeper) ProcessFeeUpdates(ctx sdk.Context) error {
 			return err
 		}
 
-		// TODO emit events
+		pubKeyHex := hex.EncodeToString(pubkey)
+		ctx.EventManager().EmitEvent(sdk.NewEvent(types.EventTypeFeeUpdate,
+			sdk.NewAttribute(types.AttributePubKey, pubKeyHex),
+			sdk.NewAttribute(types.AttributeFee, proxyConfig.Fee.String())))
 	}
 	return nil
 }

--- a/x/data-proxy/types/events.go
+++ b/x/data-proxy/types/events.go
@@ -1,5 +1,16 @@
 package types
 
 const (
-	EventTypeRegisterProxy = "register_proxy"
+	EventTypeRegisterProxy = "register_data_proxy"
+	EventTypeEditProxy     = "edit_data_proxy"
+	EventTypeFeeUpdate     = "fee_update"
+	EventTypeTransferAdmin = "transfer_admin"
+
+	AttributePubKey        = "pub_key"
+	AttributePayoutAddress = "payout_address"
+	AttributeFee           = "fee"
+	AttributeMemo          = "memo"
+	AttributeAdminAddress  = "admin_address"
+	AttributeNewFee        = "new_fee"
+	AttributeNewFeeHeight  = "new_fee_height"
 )


### PR DESCRIPTION
## Motivation

Easier to see in the explorer what the effects were of a transaction or endblock state mutation.

## Explanation of Changes

Followed the example from other modules (tally and wasm-storage).

## Testing

N.A.

## Related PRs and Issues

Part-of: #316
