### PR TITLE
Additional validation and improved errors

### DIFF
--- a/x/data-proxy/keeper/msg_server.go
+++ b/x/data-proxy/keeper/msg_server.go
@@ -138,8 +138,6 @@ func (m msgServer) EditDataProxy(goCtx context.Context, msg *types.MsgEditDataPr
 		return &types.MsgEditDataProxyResponse{}, nil
 	}
 
-	// TODO check if fee is in native denom
-
 	params, err := m.Keeper.Params.Get(ctx)
 	if err != nil {
 		return nil, err
@@ -229,7 +227,7 @@ func (m msgServer) UpdateParams(goCtx context.Context, req *types.MsgUpdateParam
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	if _, err := sdk.AccAddressFromBech32(req.Authority); err != nil {
-		return nil, fmt.Errorf("invalid authority address: %s", err)
+		return nil, sdkerrors.ErrInvalidAddress.Wrapf("invalid authority address: %s", req.Authority)
 	}
 	if m.GetAuthority() != req.Authority {
 		return nil, sdkerrors.ErrorInvalidSigner.Wrapf("unauthorized authority; expected %s, got %s", m.GetAuthority(), req.Authority)

--- a/x/data-proxy/types/errors.go
+++ b/x/data-proxy/types/errors.go
@@ -3,10 +3,8 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrEmptyValue       = errors.Register(ModuleName, 1, "empty value")
-	ErrInvalidParam     = errors.Register(ModuleName, 2, "invalid parameter")
-	ErrAlreadyExists    = errors.Register(ModuleName, 3, "data proxy already exists")
-	ErrInvalidSignature = errors.Register(ModuleName, 4, "invalid signature")
-	ErrInvalidDelay     = errors.Register(ModuleName, 5, "invalid update delay")
-	ErrEmptyUpdate      = errors.Register(ModuleName, 6, "nothing to update")
+	ErrAlreadyExists    = errors.Register(ModuleName, 2, "data proxy already exists")
+	ErrInvalidSignature = errors.Register(ModuleName, 3, "invalid signature")
+	ErrInvalidDelay     = errors.Register(ModuleName, 4, "invalid update delay")
+	ErrEmptyUpdate      = errors.Register(ModuleName, 5, "nothing to update")
 )

--- a/x/data-proxy/types/params.go
+++ b/x/data-proxy/types/params.go
@@ -1,11 +1,12 @@
 package types
 
 import (
-	"cosmossdk.io/errors"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
 const (
 	DefaultMinFeeUpdateDelay uint32 = 86400 // Roughly 1 week with a ~7 sec block time
+	LowestFeeUpdateDelay     uint32 = 1
 )
 
 // DefaultParams returns default wasm-storage module parameters.
@@ -18,8 +19,8 @@ func DefaultParams() Params {
 // ValidateBasic performs basic validation on wasm-storage
 // module parameters.
 func (p *Params) Validate() error {
-	if p.MinFeeUpdateDelay < 1 {
-		return errors.Wrapf(ErrInvalidParam, "MinFeeUpdateDelay %d < 1", p.MinFeeUpdateDelay)
+	if p.MinFeeUpdateDelay < LowestFeeUpdateDelay {
+		return sdkerrors.ErrInvalidRequest.Wrapf("MinFeeUpdateDelay lower than %d < %d", p.MinFeeUpdateDelay, LowestFeeUpdateDelay)
 	}
 	return nil
 }

--- a/x/data-proxy/types/proxy_config.go
+++ b/x/data-proxy/types/proxy_config.go
@@ -1,5 +1,7 @@
 package types
 
+import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
 const (
 	MaxMemoLength    = 3000
 	DoNotModifyField = "[do-not-modify]"
@@ -8,7 +10,7 @@ const (
 
 func (p *ProxyConfig) Validate() error {
 	if len(p.Memo) > MaxMemoLength {
-		return ErrInvalidParam.Wrapf("invalid memo length; got: %d, max < %d", len(p.Memo), MaxMemoLength)
+		return sdkerrors.ErrInvalidRequest.Wrapf("invalid memo length; got: %d, max < %d", len(p.Memo), MaxMemoLength)
 	}
 
 	return nil


### PR DESCRIPTION
## Motivation

Make errors more in line with the changes introduced in #333 and adds additional validation on TXs.

## Explanation of Changes

We decided to check the denom through the appparam const as it seems that changing the denom in the staking keeper wouldn't work anyway.

## Testing

Add unit tests to verify that param changes don't affect pending updates.

## Related PRs and Issues

Part-of: #316

