### PR TITLE
Publish data proxy messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ fmt:
 ###                                Linting                                  ###
 ###############################################################################
 
-golangci_version=v1.53.3
+golangci_version=v1.60.3
 
 lint-install:
 	@echo "--> Installing golangci-lint $(golangci_version)"

--- a/app/app.go
+++ b/app/app.go
@@ -130,7 +130,6 @@ import (
 
 	"github.com/sedaprotocol/seda-chain/app/keepers"
 	appparams "github.com/sedaprotocol/seda-chain/app/params"
-
 	// Used in cosmos-sdk when registering the route for swagger docs.
 	_ "github.com/sedaprotocol/seda-chain/client/docs/statik"
 	dataproxy "github.com/sedaprotocol/seda-chain/x/data-proxy"

--- a/e2e/e2e_gov_test.go
+++ b/e2e/e2e_gov_test.go
@@ -192,7 +192,7 @@ func (s *IntegrationTestSuite) execGetSeedQuery(
 }
 
 func (s *IntegrationTestSuite) validateGetSeedResponse(expectEmpty bool) func([]byte, []byte) bool {
-	return func(stdOut, stdErr []byte) bool {
+	return func(stdOut, _ []byte) bool {
 		var getSeedResponse struct {
 			Data struct {
 				BlockHeight int    `json:"block_height"`

--- a/interchaintest/chain_core_test.go
+++ b/interchaintest/chain_core_test.go
@@ -272,7 +272,7 @@ func testDistribution(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 
 	newWithdrawAddr := testAddresses[0]
 
-	t.Run("misc queries", func(t *testing.T) {
+	t.Run("misc queries", func(_ *testing.T) {
 		slashes, err := chain.DistributionQueryValidatorSlashes(ctx, valAddr)
 		require.NoError(err)
 		require.EqualValues(0, len(slashes))
@@ -295,7 +295,7 @@ func testDistribution(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 		require.EqualValues(chain.Config().Denom, comm.Commission[0].Denom)
 	})
 
-	t.Run("withdraw-all-rewards", func(t *testing.T) {
+	t.Run("withdraw-all-rewards", func(_ *testing.T) {
 		err = node.StakingDelegate(ctx, users[2].KeyName(), valAddr, fmt.Sprintf("%d%s", uint64(100*math.Pow10(6)), chain.Config().Denom))
 		require.NoError(err)
 
@@ -312,12 +312,12 @@ func testDistribution(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 		require.True(after.GT(before))
 	})
 
-	t.Run("fund-pools", func(t *testing.T) {
+	t.Run("fund-pools", func(_ *testing.T) {
 		bal, err := chain.BankQueryBalance(ctx, acc.String(), chain.Config().Denom)
 		require.NoError(err)
 		fmt.Printf("CP balance: %+v\n", bal)
 
-		amount := uint64(9_000 * math.Pow10(6))
+		amount := int64(9_000 * math.Pow10(6))
 
 		err = node.DistributionFundCommunityPool(ctx, users[0].KeyName(), fmt.Sprintf("%d%s", amount, chain.Config().Denom))
 		require.NoError(err)
@@ -329,15 +329,15 @@ func testDistribution(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 		require.NoError(err)
 		fmt.Printf("New CP balance: %+v\n", bal2) // 9147579661
 
-		require.True(bal2.Sub(bal).GT(sdkmath.NewInt(int64(amount))))
+		require.True(bal2.Sub(bal).GT(sdkmath.NewInt(amount)))
 
 		// queries
 		coins, err := chain.DistributionQueryCommunityPool(ctx)
 		require.NoError(err)
-		require.True(coins.AmountOf(chain.Config().Denom).GT(sdkmath.LegacyNewDec(int64(amount))))
+		require.True(coins.AmountOf(chain.Config().Denom).GT(sdkmath.LegacyNewDec((amount))))
 	})
 
-	t.Run("set-custiom-withdraw-address", func(t *testing.T) {
+	t.Run("set-custiom-withdraw-address", func(_ *testing.T) {
 		err = node.DistributionSetWithdrawAddr(ctx, users[0].KeyName(), newWithdrawAddr)
 		require.NoError(err)
 
@@ -346,7 +346,7 @@ func testDistribution(ctx context.Context, t *testing.T, chain *cosmos.CosmosCha
 		require.EqualValues(withdrawAddr, newWithdrawAddr)
 	})
 
-	t.Run("delegator", func(t *testing.T) {
+	t.Run("delegator", func(_ *testing.T) {
 		delRewards, err := chain.DistributionQueryDelegationTotalRewards(ctx, delAddr)
 		require.NoError(err)
 		r := delRewards.Rewards[0]
@@ -489,6 +489,7 @@ func testStaking(ctx context.Context, t *testing.T, chain *cosmos.CosmosChain, u
 		height, err := chain.Height(ctx)
 		require.NoError(t, err)
 
+		//nolint:gosec // G115: Test will fail if conversion overflows
 		searchHeight := int64(height - 1)
 
 		hi, err := chain.StakingQueryHistoricalInfo(ctx, searchHeight)

--- a/interchaintest/chain_upgrade_test.go
+++ b/interchaintest/chain_upgrade_test.go
@@ -205,6 +205,7 @@ func ValidatorVoting(t *testing.T, ctx context.Context, chain *cosmos.CosmosChai
 	require.NoError(t, err, "error fetching height before upgrade")
 
 	// this should timeout due to chain halt at upgrade height
+	//nolint:gosec // G115: Test will fail if conversion overflows
 	_ = testutil.WaitForBlocks(timeoutCtx, int(haltHeight-currentHeight), chain)
 
 	currentHeight, err = chain.Height(ctx)
@@ -225,7 +226,8 @@ func SubmitUpgradeProposal(t *testing.T, ctx context.Context, chain *cosmos.Cosm
 	upgradeMsg := &upgradetypes.MsgSoftwareUpgrade{
 		Authority: "seda10d07y265gmmuvt4z0w9aw880jnsr700jvvla4j", // gov module account; sedad q auth module-account gov
 		Plan: upgradetypes.Plan{
-			Name:   upgradeName,
+			Name: upgradeName,
+			//nolint:gosec // G115: Test will fail if conversion overflows
 			Height: int64(haltHeight),
 		},
 	}

--- a/interchaintest/state_sync_test.go
+++ b/interchaintest/state_sync_test.go
@@ -41,6 +41,7 @@ func TestStateSync(t *testing.T) {
 	latestHeight, err := chain.Height(ctx)
 	require.NoError(t, err, "failed to fetch latest chain height")
 
+	//nolint:gosec // G115: Test will fail if conversion overflows
 	trustHeight := int64(latestHeight) - stateSyncSnapshotInterval
 
 	firstFullNode := chain.FullNodes[0]

--- a/plugins/indexing/data-proxy/module.go
+++ b/plugins/indexing/data-proxy/module.go
@@ -1,0 +1,59 @@
+package dataproxy
+
+import (
+	"bytes"
+	"encoding/hex"
+
+	"cosmossdk.io/collections"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+	dataproxytypes "github.com/sedaprotocol/seda-chain/x/data-proxy/types"
+)
+
+const StoreKey = dataproxytypes.StoreKey
+
+func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+	if keyBytes, found := bytes.CutPrefix(change.Key, dataproxytypes.DataProxyConfigPrefix); found {
+		_, key, err := collections.BytesKey.Decode(keyBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		val, err := codec.CollValue[dataproxytypes.ProxyConfig](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			PubKey string                     `json:"pubKey"`
+			Config dataproxytypes.ProxyConfig `json:"config"`
+		}{
+			PubKey: hex.EncodeToString(key),
+			Config: val,
+		}
+
+		return types.NewMessage("data-proxy", data, ctx), nil
+	} else if _, found := bytes.CutPrefix(change.Key, dataproxytypes.ParamsPrefix); found {
+		val, err := codec.CollValue[dataproxytypes.Params](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ModuleName string                `json:"moduleName"`
+			Params     dataproxytypes.Params `json:"params"`
+		}{
+			ModuleName: "staking",
+			Params:     val,
+		}
+
+		return types.NewMessage("module-params", data, ctx), nil
+	}
+
+	logger.Trace("skipping change", "change", change)
+	return nil, nil
+}

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/auth"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/bank"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/base"
+	dataproxy "github.com/sedaprotocol/seda-chain/plugins/indexing/data-proxy"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/pluginaws"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/staking"
@@ -90,6 +91,8 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 		return auth.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case staking.StoreKey:
 		return staking.ExtractUpdate(p.block, p.cdc, p.logger, change)
+	case dataproxy.StoreKey:
+		return dataproxy.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	default:
 		return nil, nil
 	}

--- a/simulation/helpers_test.go
+++ b/simulation/helpers_test.go
@@ -220,7 +220,7 @@ func appStateRandomizedFn(
 
 	appParams.GetOrGenerate(
 		StakePerAccount, &initialStake, r,
-		func(r *rand.Rand) {
+		func(_ *rand.Rand) {
 			initialStake = math.NewIntFromBigInt(initialStakeAmount)
 		},
 	)

--- a/x/tally/keeper/filter_fuzz_test.go
+++ b/x/tally/keeper/filter_fuzz_test.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"slices"
 
 	"github.com/sedaprotocol/seda-chain/x/tally/keeper"
 	"github.com/sedaprotocol/seda-chain/x/tally/types"

--- a/x/tally/types/filters.go
+++ b/x/tally/types/filters.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"encoding/binary"
-
 	"slices"
 
 	"golang.org/x/exp/constraints"

--- a/x/wasm-storage/keeper/msg_server_test.go
+++ b/x/wasm-storage/keeper/msg_server_test.go
@@ -3,16 +3,12 @@ package keeper_test
 import (
 	"encoding/hex"
 	"os"
-	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/stretchr/testify/require"
 
 	"github.com/CosmWasm/wasmd/x/wasm/ioutils"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	"github.com/sedaprotocol/seda-chain/x/wasm-storage/keeper"
+	// "github.com/sedaprotocol/seda-chain/x/wasm-storage/keeper"
 	"github.com/sedaprotocol/seda-chain/x/wasm-storage/types"
 )
 
@@ -201,12 +197,12 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	authority := s.keeper.GetAuthority()
 	cases := []struct {
 		name      string
-		input     types.MsgUpdateParams
+		input     *types.MsgUpdateParams
 		expErrMsg string
 	}{
 		{
 			name: "happy path",
-			input: types.MsgUpdateParams{
+			input: &types.MsgUpdateParams{
 				Authority: s.authority,
 				Params: types.Params{
 					MaxWasmSize: 1000000, // 1 MB
@@ -217,7 +213,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 		},
 		{
 			name: "invalid authority",
-			input: types.MsgUpdateParams{
+			input: &types.MsgUpdateParams{
 				Authority: "seda1ucv5709wlf9jn84ynyjzyzeavwvurmdyxat26l",
 				Params: types.Params{
 					MaxWasmSize: 1, // 1 MB
@@ -228,7 +224,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 		},
 		{
 			name: "invalid max wasm size",
-			input: types.MsgUpdateParams{
+			input: &types.MsgUpdateParams{
 				Authority: authority,
 				Params: types.Params{
 					MaxWasmSize: 0, // 0 MB
@@ -239,7 +235,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 		},
 		{
 			name: "invalid wasm time to live",
-			input: types.MsgUpdateParams{
+			input: &types.MsgUpdateParams{
 				Authority: authority,
 				Params: types.Params{
 					MaxWasmSize: 111110,
@@ -253,7 +249,7 @@ func (s *KeeperTestSuite) TestUpdateParams() {
 	s.SetupTest()
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
-			_, err := s.msgSrvr.UpdateParams(s.ctx, &tc.input)
+			_, err := s.msgSrvr.UpdateParams(s.ctx, tc.input)
 			if tc.expErrMsg != "" {
 				s.Require().Error(err)
 				s.Require().Equal(tc.expErrMsg, err.Error())
@@ -354,7 +350,6 @@ func (s *KeeperTestSuite) TestDRWasmPruning() {
 	s.Require().Empty(list) // Check WsmExp is in sync
 	s.Require().Empty(getAllWasmExpEntry(s.T(), s.ctx, s.keeper))
 }
-*/
 
 func getAllWasmExpEntry(t *testing.T, c sdk.Context, k *keeper.Keeper) []string {
 	t.Helper()
@@ -368,3 +363,4 @@ func getAllWasmExpEntry(t *testing.T, c sdk.Context, k *keeper.Keeper) []string 
 	}
 	return hashes
 }
+*/


### PR DESCRIPTION
Targeting the wasm expiration branch to make merging simpler.

## Motivation

Publish changes in the data-proxy store on the SQS queue.

## Explanation of Changes

Also updated the linter as it was complaining about dependencies, but then it started complaining about some existing code so I had to fix that.

## Testing

Ran plugin locally and tested registering a proxy, editing a proxy (new memo, new fee), and transferring the admin address.

Example message:

```json
{
  "type": "data-proxy",
  "data": {
    "pubKey": "034c0f86f0cb61f9ddb47c4ba0b2ca0470962b5a1c50bee3a563184979672195f4",
    "config": {
      "payout_address": "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh",
      "fee": { "denom": "aseda", "amount": "10000000000000000000" },
      "memo": "test me sedaddy",
      "admin_address": "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh",
      "fee_update": {
        "new_fee": { "denom": "aseda", "amount": "100000000000000000000" },
        "update_height": 86423
      }
    }
  }
}
```

## Related PRs and Issues

Closes: #340 