### PR TITLE
Correct the module name in data-proxy params messages

### DIFF
--- a/plugins/indexing/data-proxy/module.go
+++ b/plugins/indexing/data-proxy/module.go
@@ -47,7 +47,7 @@ func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger,
 			ModuleName string                `json:"moduleName"`
 			Params     dataproxytypes.Params `json:"params"`
 		}{
-			ModuleName: "staking",
+			ModuleName: "data-proxy",
 			Params:     val,
 		}
 


### PR DESCRIPTION
## Motivation

Because the old implementation is simply wrong.

## Explanation of Changes

N.A.

## Testing

Ran locally to verify it's no longer publish as `staking`....

## Related PRs and Issues

N.A.
