### PR TITLE
Add connection reset retry to SQS

### DIFF
--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -28,8 +28,8 @@ import (
 	dataproxy "github.com/sedaprotocol/seda-chain/plugins/indexing/data-proxy"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/pluginaws"
-	"github.com/sedaprotocol/seda-chain/plugins/indexing/staking"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+	// "github.com/sedaprotocol/seda-chain/plugins/indexing/staking"
 )
 
 var _ storetypes.ABCIListener = &IndexerPlugin{}
@@ -89,8 +89,9 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 		return bank.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case auth.StoreKey:
 		return auth.ExtractUpdate(p.block, p.cdc, p.logger, change)
-	case staking.StoreKey:
-		return staking.ExtractUpdate(p.block, p.cdc, p.logger, change)
+	// Enable when indexer supports these messages
+	// case staking.StoreKey:
+	// 	return staking.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case dataproxy.StoreKey:
 		return dataproxy.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	default:

--- a/plugins/indexing/pluginaws/aws_session.go
+++ b/plugins/indexing/pluginaws/aws_session.go
@@ -4,8 +4,6 @@ package pluginaws
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -17,12 +15,6 @@ func NewSession() (*session.Session, error) {
 
 func NewS3Config() (*aws.Config, error) {
 	cfg := aws.NewConfig()
-	request.WithRetryer(cfg, CustomRetryer{DefaultRetryer: client.DefaultRetryer{
-		NumMaxRetries:    client.DefaultRetryerMaxNumRetries,
-		MinRetryDelay:    client.DefaultRetryerMinRetryDelay,
-		MaxRetryDelay:    client.DefaultRetryerMaxRetryDelay,
-		MinThrottleDelay: client.DefaultRetryerMinThrottleDelay,
-		MaxThrottleDelay: client.DefaultRetryerMaxThrottleDelay,
-	}})
+	AddRetryToConfig(cfg)
 	return cfg, nil
 }

--- a/plugins/indexing/pluginaws/aws_session_dev.go
+++ b/plugins/indexing/pluginaws/aws_session_dev.go
@@ -7,9 +7,7 @@ import (
 	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
 
@@ -38,12 +36,6 @@ func NewS3Config() (*aws.Config, error) {
 	}
 	// The local emulator requires path style access
 	cfg := aws.NewConfig().WithEndpoint(endpoint).WithS3ForcePathStyle(true)
-	request.WithRetryer(cfg, CustomRetryer{DefaultRetryer: client.DefaultRetryer{
-		NumMaxRetries:    client.DefaultRetryerMaxNumRetries,
-		MinRetryDelay:    client.DefaultRetryerMinRetryDelay,
-		MaxRetryDelay:    client.DefaultRetryerMaxRetryDelay,
-		MinThrottleDelay: client.DefaultRetryerMinThrottleDelay,
-		MaxThrottleDelay: client.DefaultRetryerMaxThrottleDelay,
-	}})
+	AddRetryToConfig(cfg)
 	return cfg, nil
 }

--- a/plugins/indexing/pluginaws/custom_retryer.go
+++ b/plugins/indexing/pluginaws/custom_retryer.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
 	"github.com/aws/aws-sdk-go/aws/request"
 )
@@ -27,4 +28,16 @@ func (r CustomRetryer) ShouldRetry(req *request.Request) bool {
 
 	// Fallback to SDK's built in retry rules
 	return r.DefaultRetryer.ShouldRetry(req)
+}
+
+func AddRetryToConfig(cfg *aws.Config) *aws.Config {
+	request.WithRetryer(cfg, CustomRetryer{DefaultRetryer: client.DefaultRetryer{
+		NumMaxRetries:    client.DefaultRetryerMaxNumRetries,
+		MinRetryDelay:    client.DefaultRetryerMinRetryDelay,
+		MaxRetryDelay:    client.DefaultRetryerMaxRetryDelay,
+		MinThrottleDelay: client.DefaultRetryerMinThrottleDelay,
+		MaxThrottleDelay: client.DefaultRetryerMaxThrottleDelay,
+	}})
+
+	return cfg
 }

--- a/plugins/indexing/pluginaws/types.go
+++ b/plugins/indexing/pluginaws/types.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sqs"
 
@@ -47,7 +48,9 @@ func NewSqsClient(logger *log.Logger) (*SqsClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialise session: %w", err)
 	}
-	awsSqsClient := sqs.New(sess)
+	sqsConfig := aws.NewConfig()
+	AddRetryToConfig(sqsConfig)
+	awsSqsClient := sqs.New(sess, sqsConfig)
 
 	s3Config, err := NewS3Config()
 	if err != nil {


### PR DESCRIPTION
## Motivation

See #362 

## Explanation of Changes

Make it easier to apply the retry logic to different configs, and the config to the SQS client.

Also disable the staking messages in the plugin. Before we kept an allowlist of message types that didn't include anything from the staking module, but as it'll probably be a while before we add support for those I figure it's easier to just disable the functionality at the plugin level.

## Testing

Confirm messages still get sent locally. Difficult to trigger a connection reset error locally though, but worst case it doesn't retry which is the same behaviour we have right now.

## Related PRs and Issues

Closes: #362 