### PR TITLE
Publish oracle program events

### DIFF
--- a/plugins/indexing/oracle-program/module.go
+++ b/plugins/indexing/oracle-program/module.go
@@ -1,0 +1,58 @@
+package oracleprogram
+
+import (
+	"bytes"
+	"encoding/hex"
+	"time"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+	oracleprogramtypes "github.com/sedaprotocol/seda-chain/x/wasm-storage/types"
+)
+
+const StoreKey = oracleprogramtypes.StoreKey
+
+func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+	if _, found := bytes.CutPrefix(change.Key, oracleprogramtypes.DataRequestPrefix); found {
+		val, err := codec.CollValue[oracleprogramtypes.DataRequestWasm](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			Id               string    `json:"id"`
+			Bytecode         []byte    `json:"bytecode"`
+			AddedAt          time.Time `json:"addedAt"`
+			ExpirationHeight int64     `json:"expirationHeight"`
+		}{
+			Id:               hex.EncodeToString(val.Hash),
+			Bytecode:         val.Bytecode,
+			AddedAt:          val.AddedAt,
+			ExpirationHeight: val.ExpirationHeight,
+		}
+
+		return types.NewMessage("oracle-program", data, ctx), nil
+	} else if _, found := bytes.CutPrefix(change.Key, oracleprogramtypes.ParamsPrefix); found {
+		val, err := codec.CollValue[oracleprogramtypes.Params](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ModuleName string                    `json:"moduleName"`
+			Params     oracleprogramtypes.Params `json:"params"`
+		}{
+			ModuleName: "oracle-program-storage",
+			Params:     val,
+		}
+
+		return types.NewMessage("module-params", data, ctx), nil
+	}
+
+	logger.Trace("skipping change", "change", change)
+	return nil, nil
+}

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -27,9 +27,9 @@ import (
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/base"
 	dataproxy "github.com/sedaprotocol/seda-chain/plugins/indexing/data-proxy"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	oracleprogram "github.com/sedaprotocol/seda-chain/plugins/indexing/oracle-program"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/pluginaws"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
-	// "github.com/sedaprotocol/seda-chain/plugins/indexing/staking"
 )
 
 var _ storetypes.ABCIListener = &IndexerPlugin{}
@@ -94,6 +94,8 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 	// 	return staking.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case dataproxy.StoreKey:
 		return dataproxy.ExtractUpdate(p.block, p.cdc, p.logger, change)
+	case oracleprogram.StoreKey:
+		return oracleprogram.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
## Motivation

Allow the explorer to display a list of uploaded Oracle Programs as well as the status and expiration height (if set).

## Explanation of Changes

We take the bytecode from the store as this simplifies the indexing process, despite also having the bytecode in the original transaction.

Used the oracle-program name to be a little bit more future proof 😅 

## Testing

Ran the chain locally with SQS and S3 emulators.

After uploading a WASM we get the following event:

```json
{
	"type": "oracle-program",
	"data": {
		"id": "605244b203c3039b0c3d61821cf9147f4c76fa137054ac72c74d6f1a6864e56b",
		"bytecode": "<BYTES>",
		"addedAt": "2024-09-30T15:08:05.836221Z",
		"expirationHeight": 0
	}
}
```

And for the parameters we get:

```json
{
	"type": "module-params",
	"data": {
		"moduleName": "oracle-program-storage",
		"params": { "max_wasm_size": 819200, "wasm_ttl": 259200 }
	}
}
```

## Related PRs and Issues

Closes: #289
