### PR TITLE
feat (batching): batch number assignment and data result query

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -982,14 +982,10 @@ func NewApp(
 	app.SetEndBlocker(app.EndBlocker)
 
 	// Register ABCI handlers for batch signing.
-<<<<<<< HEAD
 	defaultProposalHandler := baseapp.NewDefaultProposalHandler(mempool.NoOpMempool{}, bApp)
 
 	abciHandler := appabci.NewHandlers(
 		defaultProposalHandler,
-=======
-	abciHandler := appabci.NewHandlers(
->>>>>>> 844ae12 (chore: register app-level preblocker on top of module-level preblockers)
 		app.BatchingKeeper,
 		app.PubKeyKeeper,
 		app.StakingKeeper,

--- a/app/app.go
+++ b/app/app.go
@@ -982,10 +982,14 @@ func NewApp(
 	app.SetEndBlocker(app.EndBlocker)
 
 	// Register ABCI handlers for batch signing.
+<<<<<<< HEAD
 	defaultProposalHandler := baseapp.NewDefaultProposalHandler(mempool.NoOpMempool{}, bApp)
 
 	abciHandler := appabci.NewHandlers(
 		defaultProposalHandler,
+=======
+	abciHandler := appabci.NewHandlers(
+>>>>>>> 844ae12 (chore: register app-level preblocker on top of module-level preblockers)
 		app.BatchingKeeper,
 		app.PubKeyKeeper,
 		app.StakingKeeper,

--- a/proto/sedachain/batching/v1/genesis.proto
+++ b/proto/sedachain/batching/v1/genesis.proto
@@ -13,5 +13,15 @@ message GenesisState {
   uint64 current_batch_number = 1;
   repeated Batch batches = 2 [ (gogoproto.nullable) = false ];
   repeated TreeEntries tree_entries = 3 [ (gogoproto.nullable) = false ];
-  Params params = 4 [ (gogoproto.nullable) = false ];
+  repeated DataResult data_results = 4 [ (gogoproto.nullable) = false ];
+  repeated BatchAssignment batch_assignments = 5
+      [ (gogoproto.nullable) = false ];
+  Params params = 6 [ (gogoproto.nullable) = false ];
+}
+
+// BatchAssignment represents a batch assignment for genesis export
+// and import.
+message BatchAssignment {
+  uint64 batch_number = 1;
+  string data_request_id = 2;
 }

--- a/proto/sedachain/batching/v1/query.proto
+++ b/proto/sedachain/batching/v1/query.proto
@@ -39,6 +39,21 @@ service Query {
     option (google.api.http).get =
         "/seda-chain/batching/batch_signatures/{batch_number}";
   }
+
+  // DataResult returns a data result given its associated data request's
+  // ID.
+  rpc DataResult(QueryDataResultRequest) returns (QueryDataResultResponse) {
+    option (google.api.http).get =
+        "/seda-chain/batching/data_result/{data_request_id}";
+  }
+
+  // BatchAssignment returns the batch number that a given data request
+  // has been assigned to.
+  rpc BatchAssignment(QueryBatchAssignmentRequest)
+      returns (QueryBatchAssignmentResponse) {
+    option (google.api.http).get =
+        "/seda-chain/batching/batch_assignment/{data_request_id}";
+  }
 }
 
 // The request message for QueryBatch RPC.
@@ -78,3 +93,17 @@ message QueryBatchSignaturesRequest { uint64 batch_number = 1; }
 message QueryBatchSignaturesResponse {
   repeated BatchSignatures batch_sigs = 1 [ (gogoproto.nullable) = false ];
 }
+
+// The request message for QueryDataResult RPC.
+message QueryDataResultRequest { string data_request_id = 1; }
+
+// The response message for QueryDataResult RPC.
+message QueryDataResultResponse {
+  DataResult data_result = 1 [ (gogoproto.nullable) = false ];
+}
+
+// The request message for QueryBatchAssignment RPC.
+message QueryBatchAssignmentRequest { string data_request_id = 1; }
+
+// The response message for QueryBatchAssignment RPC.
+message QueryBatchAssignmentResponse { uint64 batch_number = 1; }

--- a/x/batching/client/cli/query.go
+++ b/x/batching/client/cli/query.go
@@ -28,6 +28,8 @@ func GetQueryCmd(_ string) *cobra.Command {
 		GetCmdQueryBatches(),
 		GetCmdQueryTreeEntries(),
 		GetCmdQueryBatchSignatures(),
+		GetCmdQueryDataResult(),
+		GetCmdQueryBatchAssignment(),
 	)
 	return cmd
 }
@@ -179,6 +181,64 @@ func GetCmdQueryBatchSignatures() *cobra.Command {
 				BatchNumber: batchNum,
 			}
 			res, err := queryClient.BatchSignatures(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// GetCmdQueryBatch returns the command for querying a data result
+// associated with a given data request.
+func GetCmdQueryDataResult() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "data-result <data_request_id>",
+		Short: "Get the data result associated with a given data request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			req := &types.QueryDataResultRequest{
+				DataRequestId: args[0],
+			}
+			res, err := queryClient.DataResult(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+	return cmd
+}
+
+// GetCmdQueryBatchAssignment returns the command for querying the
+// batch number assigned to the given data request.
+func GetCmdQueryBatchAssignment() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "batch-assignment <data_request_id>",
+		Short: "Get the batch number assigned to a given data request",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+			queryClient := types.NewQueryClient(clientCtx)
+
+			req := &types.QueryBatchAssignmentRequest{
+				DataRequestId: args[0],
+			}
+			res, err := queryClient.BatchAssignment(cmd.Context(), req)
 			if err != nil {
 				return err
 			}

--- a/x/batching/keeper/abci_test.go
+++ b/x/batching/keeper/abci_test.go
@@ -33,7 +33,7 @@ func Test_ConstructDataResultTree(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	entries, root, err := f.batchingKeeper.ConstructDataResultTree(f.Context())
+	entries, root, err := f.batchingKeeper.ConstructDataResultTree(f.Context(), rand.Uint64())
 	require.NoError(t, err)
 
 	var entryHexes, drIds []string

--- a/x/batching/keeper/data_result.go
+++ b/x/batching/keeper/data_result.go
@@ -38,6 +38,9 @@ func (k Keeper) GetDataResult(ctx context.Context, dataReqID string) (types.Data
 			// Look among batched data requests.
 			dataResult, err := k.dataResults.Get(ctx, collections.Join(true, dataReqID))
 			if err != nil {
+				if errors.Is(err, collections.ErrNotFound) {
+					return types.DataResult{}, nil
+				}
 				return types.DataResult{}, err
 			}
 			return dataResult, nil

--- a/x/batching/keeper/data_result.go
+++ b/x/batching/keeper/data_result.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
 	"cosmossdk.io/collections"
 
@@ -16,12 +17,34 @@ func (k Keeper) SetDataResultForBatching(ctx context.Context, result types.DataR
 
 // markDataResultAsBatched removes the "unbatched" variant of the given
 // data result and stores a "batched" variant.
-func (k Keeper) markDataResultAsBatched(ctx context.Context, result types.DataResult) error {
-	err := k.dataResults.Remove(ctx, collections.Join(false, result.DrId))
+func (k Keeper) markDataResultAsBatched(ctx context.Context, result types.DataResult, batchNum uint64) error {
+	err := k.SetBatchAssignment(ctx, result.DrId, batchNum)
+	if err != nil {
+		return err
+	}
+	err = k.dataResults.Remove(ctx, collections.Join(false, result.DrId))
 	if err != nil {
 		return err
 	}
 	return k.dataResults.Set(ctx, collections.Join(true, result.DrId), result)
+}
+
+// GetDataResult returns a data result given the associated data request's
+// ID.
+func (k Keeper) GetDataResult(ctx context.Context, dataReqID string) (types.DataResult, error) {
+	dataResult, err := k.dataResults.Get(ctx, collections.Join(false, dataReqID))
+	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			// Look among batched data requests.
+			dataResult, err := k.dataResults.Get(ctx, collections.Join(true, dataReqID))
+			if err != nil {
+				return types.DataResult{}, err
+			}
+			return dataResult, nil
+		}
+		return types.DataResult{}, err
+	}
+	return dataResult, err
 }
 
 // GetDataResults returns a list of data results under a given status
@@ -35,9 +58,51 @@ func (k Keeper) GetDataResults(ctx context.Context, batched bool) ([]types.DataR
 	return results, err
 }
 
+// getAllDataResults returns all data results from the store regardless
+// of their batched status.
+func (k Keeper) getAllDataResults(ctx context.Context) ([]types.DataResult, error) {
+	var dataResults []types.DataResult
+	unbatched, err := k.GetDataResults(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	dataResults = append(dataResults, unbatched...)
+	batched, err := k.GetDataResults(ctx, true)
+	if err != nil {
+		return nil, err
+	}
+	dataResults = append(dataResults, batched...)
+	return dataResults, nil
+}
+
 // IterateDataResults iterates over all data results under a given
 // status (batched or not) and performs a given callback function.
 func (k Keeper) IterateDataResults(ctx context.Context, batched bool, cb func(key collections.Pair[bool, string], value types.DataResult) (bool, error)) error {
 	rng := collections.NewPrefixedPairRange[bool, string](batched)
 	return k.dataResults.Walk(ctx, rng, cb)
+}
+
+// SetBatchAssignment assigns a given batch number to the given data
+// request.
+func (k Keeper) SetBatchAssignment(ctx context.Context, dataReqID string, batchNumber uint64) error {
+	return k.batchAssignments.Set(ctx, dataReqID, batchNumber)
+}
+
+// GetBatchAssignment returns the given data request's assigned batch
+// number.
+func (k Keeper) GetBatchAssignment(ctx context.Context, dataReqID string) (uint64, error) {
+	return k.batchAssignments.Get(ctx, dataReqID)
+}
+
+// getAllBatchAssignments retrieves all batch assignments from the store.
+func (k Keeper) getAllBatchAssignments(ctx context.Context) ([]types.BatchAssignment, error) {
+	var batchAssignments []types.BatchAssignment
+	err := k.batchAssignments.Walk(ctx, nil, func(dataReqID string, batchNum uint64) (stop bool, err error) {
+		batchAssignments = append(batchAssignments, types.BatchAssignment{
+			BatchNumber:   batchNum,
+			DataRequestId: dataReqID,
+		})
+		return false, nil
+	})
+	return batchAssignments, err
 }

--- a/x/batching/keeper/endblock.go
+++ b/x/batching/keeper/endblock.go
@@ -55,7 +55,7 @@ func (k Keeper) ConstructBatch(ctx sdk.Context) (types.Batch, [][]byte, [][]byte
 	}
 	newBatchNum := oldBatchNum + 1
 
-	dataEntries, dataRoot, err := k.ConstructDataResultTree(ctx)
+	dataEntries, dataRoot, err := k.ConstructDataResultTree(ctx, newBatchNum)
 	if err != nil {
 		return types.Batch{}, nil, nil, err
 	}
@@ -90,7 +90,7 @@ func (k Keeper) ConstructBatch(ctx sdk.Context) (types.Batch, [][]byte, [][]byte
 // ConstructDataResultTree constructs a data result tree based on the
 // data results that have not been batched yet. It returns the tree's
 // entries (unhashed leaf contents) and hex-encoded root.
-func (k Keeper) ConstructDataResultTree(ctx sdk.Context) ([][]byte, []byte, error) {
+func (k Keeper) ConstructDataResultTree(ctx sdk.Context, newBatchNum uint64) ([][]byte, []byte, error) {
 	dataResults, err := k.GetDataResults(ctx, false)
 	if err != nil {
 		return nil, nil, err
@@ -104,7 +104,7 @@ func (k Keeper) ConstructDataResultTree(ctx sdk.Context) ([][]byte, []byte, erro
 		}
 		entries[i] = resHash
 
-		err = k.markDataResultAsBatched(ctx, res)
+		err = k.markDataResultAsBatched(ctx, res, newBatchNum)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/x/batching/keeper/genesis.go
+++ b/x/batching/keeper/genesis.go
@@ -28,6 +28,14 @@ func (k Keeper) InitGenesis(ctx sdk.Context, data types.GenesisState) {
 
 // ExportGenesis extracts all data from store to genesis state.
 func (k Keeper) ExportGenesis(ctx sdk.Context) types.GenesisState {
+	dataResults, err := k.getAllDataResults(ctx)
+	if err != nil {
+		panic(err)
+	}
+	batchAssignments, err := k.getAllBatchAssignments(ctx)
+	if err != nil {
+		panic(err)
+	}
 	curBatchNum, err := k.GetCurrentBatchNum(ctx)
 	if err != nil {
 		panic(err)
@@ -44,5 +52,5 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) types.GenesisState {
 	if err != nil {
 		panic(err)
 	}
-	return types.NewGenesisState(curBatchNum, batches, entries, params)
+	return types.NewGenesisState(curBatchNum, batches, entries, dataResults, batchAssignments, params)
 }

--- a/x/batching/keeper/keeper.go
+++ b/x/batching/keeper/keeper.go
@@ -31,6 +31,7 @@ type Keeper struct {
 
 	Schema             collections.Schema
 	dataResults        collections.Map[collections.Pair[bool, string], types.DataResult]
+	batchAssignments   collections.Map[string, uint64]
 	currentBatchNumber collections.Sequence
 	batches            *collections.IndexedMap[int64, types.Batch, BatchIndexes]
 	treeEntries        collections.Map[uint64, types.TreeEntries]
@@ -60,6 +61,7 @@ func NewKeeper(
 		validatorAddressCodec: validatorAddressCodec,
 		authority:             authority,
 		dataResults:           collections.NewMap(sb, types.DataResultsPrefix, "data_results", collections.PairKeyCodec(collections.BoolKey, collections.StringKey), codec.CollValue[types.DataResult](cdc)),
+		batchAssignments:      collections.NewMap(sb, types.BatchAssignmentsPrefix, "batch_assignments", collections.StringKey, collections.Uint64Value),
 		currentBatchNumber:    collections.NewSequence(sb, types.CurrentBatchNumberKey, "current_batch_number"),
 		batches:               collections.NewIndexedMap(sb, types.BatchesKeyPrefix, "batches", collections.Int64Key, codec.CollValue[types.Batch](cdc), NewBatchIndexes(sb)),
 		treeEntries:           collections.NewMap(sb, types.TreeEntriesKeyPrefix, "tree_entries", collections.Uint64Key, codec.CollValue[types.TreeEntries](cdc)),
@@ -91,9 +93,9 @@ type BatchIndexes struct {
 	Number *indexes.Unique[uint64, int64, types.Batch]
 }
 
-func (a BatchIndexes) IndexesList() []collections.Index[int64, types.Batch] {
+func (i BatchIndexes) IndexesList() []collections.Index[int64, types.Batch] {
 	return []collections.Index[int64, types.Batch]{
-		a.Number,
+		i.Number,
 	}
 }
 

--- a/x/batching/keeper/querier.go
+++ b/x/batching/keeper/querier.go
@@ -74,3 +74,25 @@ func (q Querier) BatchSignatures(c context.Context, req *types.QueryBatchSignatu
 		BatchSigs: sigs,
 	}, nil
 }
+
+func (q Querier) DataResult(c context.Context, req *types.QueryDataResultRequest) (*types.QueryDataResultResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	dataResult, err := q.Keeper.GetDataResult(ctx, req.DataRequestId)
+	if err != nil {
+		return nil, err
+	}
+	return &types.QueryDataResultResponse{
+		DataResult: dataResult,
+	}, nil
+}
+
+func (q Querier) BatchAssignment(c context.Context, req *types.QueryBatchAssignmentRequest) (*types.QueryBatchAssignmentResponse, error) {
+	ctx := sdk.UnwrapSDKContext(c)
+	batchNum, err := q.Keeper.GetBatchAssignment(ctx, req.DataRequestId)
+	if err != nil {
+		return nil, err
+	}
+	return &types.QueryBatchAssignmentResponse{
+		BatchNumber: batchNum,
+	}, nil
+}

--- a/x/batching/types/genesis.go
+++ b/x/batching/types/genesis.go
@@ -3,18 +3,27 @@ package types
 import "cosmossdk.io/collections"
 
 // NewGenesisState constructs a GenesisState object.
-func NewGenesisState(curBatchNum uint64, batches []Batch, entries []TreeEntries, params Params) GenesisState {
+func NewGenesisState(
+	curBatchNum uint64,
+	batches []Batch,
+	entries []TreeEntries,
+	dataResults []DataResult,
+	batchAssignments []BatchAssignment,
+	params Params,
+) GenesisState {
 	return GenesisState{
 		CurrentBatchNumber: curBatchNum,
 		Batches:            batches,
 		TreeEntries:        entries,
+		DataResults:        dataResults,
+		BatchAssignments:   batchAssignments,
 		Params:             params,
 	}
 }
 
 // DefaultGenesisState creates a default GenesisState object.
 func DefaultGenesisState() *GenesisState {
-	state := NewGenesisState(collections.DefaultSequenceStart, nil, nil, DefaultParams())
+	state := NewGenesisState(collections.DefaultSequenceStart, nil, nil, nil, nil, DefaultParams())
 	return &state
 }
 

--- a/x/batching/types/genesis.pb.go
+++ b/x/batching/types/genesis.pb.go
@@ -27,10 +27,12 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 type GenesisState struct {
 	// current_batch_number is the batch number of the most recently-
 	// created batch.
-	CurrentBatchNumber uint64        `protobuf:"varint,1,opt,name=current_batch_number,json=currentBatchNumber,proto3" json:"current_batch_number,omitempty"`
-	Batches            []Batch       `protobuf:"bytes,2,rep,name=batches,proto3" json:"batches"`
-	TreeEntries        []TreeEntries `protobuf:"bytes,3,rep,name=tree_entries,json=treeEntries,proto3" json:"tree_entries"`
-	Params             Params        `protobuf:"bytes,4,opt,name=params,proto3" json:"params"`
+	CurrentBatchNumber uint64            `protobuf:"varint,1,opt,name=current_batch_number,json=currentBatchNumber,proto3" json:"current_batch_number,omitempty"`
+	Batches            []Batch           `protobuf:"bytes,2,rep,name=batches,proto3" json:"batches"`
+	TreeEntries        []TreeEntries     `protobuf:"bytes,3,rep,name=tree_entries,json=treeEntries,proto3" json:"tree_entries"`
+	DataResults        []DataResult      `protobuf:"bytes,4,rep,name=data_results,json=dataResults,proto3" json:"data_results"`
+	BatchAssignments   []BatchAssignment `protobuf:"bytes,5,rep,name=batch_assignments,json=batchAssignments,proto3" json:"batch_assignments"`
+	Params             Params            `protobuf:"bytes,6,opt,name=params,proto3" json:"params"`
 }
 
 func (m *GenesisState) Reset()         { *m = GenesisState{} }
@@ -87,6 +89,20 @@ func (m *GenesisState) GetTreeEntries() []TreeEntries {
 	return nil
 }
 
+func (m *GenesisState) GetDataResults() []DataResult {
+	if m != nil {
+		return m.DataResults
+	}
+	return nil
+}
+
+func (m *GenesisState) GetBatchAssignments() []BatchAssignment {
+	if m != nil {
+		return m.BatchAssignments
+	}
+	return nil
+}
+
 func (m *GenesisState) GetParams() Params {
 	if m != nil {
 		return m.Params
@@ -94,8 +110,63 @@ func (m *GenesisState) GetParams() Params {
 	return Params{}
 }
 
+// BatchAssignment represents a batch assignment for genesis export
+// and import.
+type BatchAssignment struct {
+	BatchNumber   uint64 `protobuf:"varint,1,opt,name=batch_number,json=batchNumber,proto3" json:"batch_number,omitempty"`
+	DataRequestId string `protobuf:"bytes,2,opt,name=data_request_id,json=dataRequestId,proto3" json:"data_request_id,omitempty"`
+}
+
+func (m *BatchAssignment) Reset()         { *m = BatchAssignment{} }
+func (m *BatchAssignment) String() string { return proto.CompactTextString(m) }
+func (*BatchAssignment) ProtoMessage()    {}
+func (*BatchAssignment) Descriptor() ([]byte, []int) {
+	return fileDescriptor_eccca5d98d3cb479, []int{1}
+}
+func (m *BatchAssignment) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BatchAssignment) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BatchAssignment.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BatchAssignment) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BatchAssignment.Merge(m, src)
+}
+func (m *BatchAssignment) XXX_Size() int {
+	return m.Size()
+}
+func (m *BatchAssignment) XXX_DiscardUnknown() {
+	xxx_messageInfo_BatchAssignment.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BatchAssignment proto.InternalMessageInfo
+
+func (m *BatchAssignment) GetBatchNumber() uint64 {
+	if m != nil {
+		return m.BatchNumber
+	}
+	return 0
+}
+
+func (m *BatchAssignment) GetDataRequestId() string {
+	if m != nil {
+		return m.DataRequestId
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*GenesisState)(nil), "sedachain.batching.v1.GenesisState")
+	proto.RegisterType((*BatchAssignment)(nil), "sedachain.batching.v1.BatchAssignment")
 }
 
 func init() {
@@ -103,26 +174,33 @@ func init() {
 }
 
 var fileDescriptor_eccca5d98d3cb479 = []byte{
-	// 302 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x90, 0xc1, 0x4e, 0xc2, 0x30,
-	0x1c, 0xc6, 0x57, 0x20, 0x98, 0x14, 0x4e, 0x0d, 0x26, 0x0b, 0xd1, 0x4a, 0xd0, 0x03, 0x17, 0x3b,
-	0x81, 0xa3, 0x9e, 0x48, 0x8c, 0x07, 0xa3, 0x31, 0xe8, 0xc9, 0x0b, 0xe9, 0xe6, 0x3f, 0xdb, 0x12,
-	0xd7, 0x2e, 0x6d, 0x47, 0xf4, 0x0d, 0x3c, 0xfa, 0x58, 0x1c, 0x39, 0x7a, 0x32, 0x66, 0x7b, 0x11,
-	0xb3, 0x6e, 0xc0, 0x05, 0x6e, 0x5b, 0xbf, 0xdf, 0xf7, 0x6b, 0xf3, 0xe1, 0x73, 0x0d, 0x6f, 0x3c,
-	0x88, 0x78, 0x2c, 0x3c, 0x9f, 0x9b, 0x20, 0x8a, 0x45, 0xe8, 0x2d, 0xc7, 0x5e, 0x08, 0x02, 0x74,
-	0xac, 0x59, 0xaa, 0xa4, 0x91, 0xe4, 0x78, 0x0b, 0xb1, 0x0d, 0xc4, 0x96, 0xe3, 0x7e, 0x2f, 0x94,
-	0xa1, 0xb4, 0x84, 0x57, 0x7e, 0x55, 0x70, 0xff, 0x62, 0xbf, 0x71, 0x5b, 0xb4, 0xd4, 0xf0, 0xab,
-	0x81, 0xbb, 0x77, 0xd5, 0x25, 0xcf, 0x86, 0x1b, 0x20, 0x57, 0xb8, 0x17, 0x64, 0x4a, 0x81, 0x30,
-	0x0b, 0x8b, 0x2e, 0x44, 0x96, 0xf8, 0xa0, 0x5c, 0x34, 0x40, 0xa3, 0xd6, 0x9c, 0xd4, 0xd9, 0xac,
-	0x8c, 0x1e, 0x6d, 0x42, 0x6e, 0xf0, 0x91, 0x25, 0x41, 0xbb, 0x8d, 0x41, 0x73, 0xd4, 0x99, 0x9c,
-	0xb0, 0xbd, 0xef, 0x64, 0xb6, 0x34, 0x6b, 0xad, 0x7e, 0xcf, 0x9c, 0xf9, 0xa6, 0x42, 0xee, 0x71,
-	0xd7, 0x28, 0x80, 0x05, 0x08, 0xa3, 0x62, 0xd0, 0x6e, 0xd3, 0x2a, 0x86, 0x07, 0x14, 0x2f, 0x0a,
-	0xe0, 0xb6, 0x22, 0x6b, 0x51, 0xc7, 0xec, 0x8e, 0xc8, 0x35, 0x6e, 0xa7, 0x5c, 0xf1, 0x44, 0xbb,
-	0xad, 0x01, 0x1a, 0x75, 0x26, 0xa7, 0x07, 0x34, 0x4f, 0x16, 0xaa, 0x0d, 0x75, 0x65, 0xf6, 0xb0,
-	0xca, 0x29, 0x5a, 0xe7, 0x14, 0xfd, 0xe5, 0x14, 0x7d, 0x17, 0xd4, 0x59, 0x17, 0xd4, 0xf9, 0x29,
-	0xa8, 0xf3, 0x3a, 0x0d, 0x63, 0x13, 0x65, 0x3e, 0x0b, 0x64, 0xe2, 0x95, 0x42, 0x3b, 0x5d, 0x20,
-	0xdf, 0xed, 0xcf, 0x65, 0xb5, 0xf1, 0xc7, 0x6e, 0x65, 0xf3, 0x99, 0x82, 0xf6, 0xdb, 0x96, 0x9a,
-	0xfe, 0x07, 0x00, 0x00, 0xff, 0xff, 0x02, 0x14, 0xa4, 0xb9, 0xda, 0x01, 0x00, 0x00,
+	// 410 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x7c, 0x92, 0x4f, 0x6e, 0xd3, 0x40,
+	0x14, 0x87, 0xed, 0x24, 0x04, 0x31, 0x36, 0x0a, 0x8c, 0x82, 0x64, 0x45, 0x60, 0x9c, 0x80, 0x22,
+	0x6f, 0xb0, 0x49, 0xb2, 0x84, 0x0d, 0x11, 0x08, 0x01, 0x02, 0x21, 0xc3, 0xa6, 0x55, 0x25, 0x6b,
+	0x6c, 0x3f, 0x39, 0x96, 0xe2, 0x71, 0x3a, 0x33, 0x8e, 0xda, 0x5b, 0xf4, 0x26, 0xbd, 0x46, 0x96,
+	0x59, 0x76, 0x55, 0x55, 0xc9, 0x45, 0xaa, 0x8c, 0x1d, 0xa7, 0xad, 0x92, 0xee, 0xec, 0xf7, 0xbe,
+	0xdf, 0x37, 0xff, 0x1e, 0x7a, 0xc7, 0x21, 0x22, 0xe1, 0x84, 0x24, 0xd4, 0x0d, 0x88, 0x08, 0x27,
+	0x09, 0x8d, 0xdd, 0xf9, 0xc0, 0x8d, 0x81, 0x02, 0x4f, 0xb8, 0x33, 0x63, 0x99, 0xc8, 0xf0, 0xab,
+	0x0a, 0x72, 0xb6, 0x90, 0x33, 0x1f, 0x74, 0xda, 0x71, 0x16, 0x67, 0x92, 0x70, 0x37, 0x5f, 0x05,
+	0xdc, 0x79, 0xbf, 0xdf, 0x58, 0x05, 0x25, 0xd5, 0xbb, 0xac, 0x23, 0xfd, 0x7b, 0xb1, 0xc8, 0x3f,
+	0x41, 0x04, 0xe0, 0x8f, 0xa8, 0x1d, 0xe6, 0x8c, 0x01, 0x15, 0xbe, 0x44, 0x7d, 0x9a, 0xa7, 0x01,
+	0x30, 0x43, 0xb5, 0x54, 0xbb, 0xe1, 0xe1, 0xb2, 0x37, 0xde, 0xb4, 0xfe, 0xc8, 0x0e, 0xfe, 0x8c,
+	0x9e, 0x4a, 0x12, 0xb8, 0x51, 0xb3, 0xea, 0xb6, 0x36, 0x7c, 0xed, 0xec, 0xdd, 0xa7, 0x23, 0x43,
+	0xe3, 0xc6, 0xe2, 0xfa, 0xad, 0xe2, 0x6d, 0x23, 0xf8, 0x17, 0xd2, 0x05, 0x03, 0xf0, 0x81, 0x0a,
+	0x96, 0x00, 0x37, 0xea, 0x52, 0xd1, 0x3b, 0xa0, 0xf8, 0xcf, 0x00, 0xbe, 0x15, 0x64, 0x29, 0xd2,
+	0xc4, 0xae, 0x84, 0x7f, 0x22, 0x3d, 0x22, 0x82, 0xf8, 0x0c, 0x78, 0x3e, 0x15, 0xdc, 0x68, 0x48,
+	0x59, 0xf7, 0x80, 0xec, 0x2b, 0x11, 0xc4, 0x93, 0xe4, 0xd6, 0x15, 0x55, 0x15, 0x8e, 0x8f, 0xd0,
+	0xcb, 0xe2, 0x02, 0x08, 0xe7, 0x49, 0x4c, 0x53, 0xa0, 0x82, 0x1b, 0x4f, 0xa4, 0xb0, 0xff, 0xd8,
+	0x01, 0xbf, 0x54, 0x78, 0x69, 0x7d, 0x11, 0xdc, 0x2f, 0x73, 0xfc, 0x09, 0x35, 0x67, 0x84, 0x91,
+	0x94, 0x1b, 0x4d, 0x4b, 0xb5, 0xb5, 0xe1, 0x9b, 0x03, 0xbe, 0xbf, 0x12, 0x2a, 0x35, 0x65, 0xa4,
+	0x77, 0x82, 0x5a, 0x0f, 0xd6, 0xc1, 0x5d, 0xa4, 0xef, 0x79, 0x2b, 0x2d, 0xb8, 0xf3, 0x48, 0x7d,
+	0xd4, 0x2a, 0x6f, 0xe6, 0x34, 0x07, 0x2e, 0xfc, 0x24, 0x32, 0x6a, 0x96, 0x6a, 0x3f, 0xf3, 0x9e,
+	0x17, 0x67, 0x96, 0xd5, 0x1f, 0xd1, 0xf8, 0xf7, 0x62, 0x65, 0xaa, 0xcb, 0x95, 0xa9, 0xde, 0xac,
+	0x4c, 0xf5, 0x62, 0x6d, 0x2a, 0xcb, 0xb5, 0xa9, 0x5c, 0xad, 0x4d, 0xe5, 0x78, 0x14, 0x27, 0x62,
+	0x92, 0x07, 0x4e, 0x98, 0xa5, 0xee, 0x66, 0xbb, 0x72, 0x7e, 0xc2, 0x6c, 0x2a, 0x7f, 0x3e, 0x14,
+	0x83, 0x76, 0xb6, 0x1b, 0x35, 0x71, 0x3e, 0x03, 0x1e, 0x34, 0x25, 0x35, 0xba, 0x0d, 0x00, 0x00,
+	0xff, 0xff, 0xed, 0x8e, 0x51, 0x01, 0xdf, 0x02, 0x00, 0x00,
 }
 
 func (m *GenesisState) Marshal() (dAtA []byte, err error) {
@@ -154,7 +232,35 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i = encodeVarintGenesis(dAtA, i, uint64(size))
 	}
 	i--
-	dAtA[i] = 0x22
+	dAtA[i] = 0x32
+	if len(m.BatchAssignments) > 0 {
+		for iNdEx := len(m.BatchAssignments) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.BatchAssignments[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if len(m.DataResults) > 0 {
+		for iNdEx := len(m.DataResults) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.DataResults[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintGenesis(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
 	if len(m.TreeEntries) > 0 {
 		for iNdEx := len(m.TreeEntries) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -185,6 +291,41 @@ func (m *GenesisState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	if m.CurrentBatchNumber != 0 {
 		i = encodeVarintGenesis(dAtA, i, uint64(m.CurrentBatchNumber))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BatchAssignment) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BatchAssignment) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BatchAssignment) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.DataRequestId) > 0 {
+		i -= len(m.DataRequestId)
+		copy(dAtA[i:], m.DataRequestId)
+		i = encodeVarintGenesis(dAtA, i, uint64(len(m.DataRequestId)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.BatchNumber != 0 {
+		i = encodeVarintGenesis(dAtA, i, uint64(m.BatchNumber))
 		i--
 		dAtA[i] = 0x8
 	}
@@ -223,8 +364,36 @@ func (m *GenesisState) Size() (n int) {
 			n += 1 + l + sovGenesis(uint64(l))
 		}
 	}
+	if len(m.DataResults) > 0 {
+		for _, e := range m.DataResults {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
+	if len(m.BatchAssignments) > 0 {
+		for _, e := range m.BatchAssignments {
+			l = e.Size()
+			n += 1 + l + sovGenesis(uint64(l))
+		}
+	}
 	l = m.Params.Size()
 	n += 1 + l + sovGenesis(uint64(l))
+	return n
+}
+
+func (m *BatchAssignment) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BatchNumber != 0 {
+		n += 1 + sovGenesis(uint64(m.BatchNumber))
+	}
+	l = len(m.DataRequestId)
+	if l > 0 {
+		n += 1 + l + sovGenesis(uint64(l))
+	}
 	return n
 }
 
@@ -352,6 +521,74 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			iNdEx = postIndex
 		case 4:
 			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataResults", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataResults = append(m.DataResults, DataResult{})
+			if err := m.DataResults[len(m.DataResults)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BatchAssignments", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BatchAssignments = append(m.BatchAssignments, BatchAssignment{})
+			if err := m.BatchAssignments[len(m.BatchAssignments)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
 			}
 			var msglen int
@@ -382,6 +619,107 @@ func (m *GenesisState) Unmarshal(dAtA []byte) error {
 			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipGenesis(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BatchAssignment) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowGenesis
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BatchAssignment: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BatchAssignment: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BatchNumber", wireType)
+			}
+			m.BatchNumber = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BatchNumber |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataRequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenesis
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenesis
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataRequestId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/x/batching/types/keys.go
+++ b/x/batching/types/keys.go
@@ -12,10 +12,11 @@ const (
 
 var (
 	DataResultsPrefix        = collections.NewPrefix(0)
-	CurrentBatchNumberKey    = collections.NewPrefix(1)
-	BatchesKeyPrefix         = collections.NewPrefix(2)
-	BatchNumberKeyPrefix     = collections.NewPrefix(3)
-	TreeEntriesKeyPrefix     = collections.NewPrefix(4)
-	BatchSignaturesKeyPrefix = collections.NewPrefix(5)
-	ParamsKey                = collections.NewPrefix(6)
+	BatchAssignmentsPrefix   = collections.NewPrefix(1)
+	CurrentBatchNumberKey    = collections.NewPrefix(2)
+	BatchesKeyPrefix         = collections.NewPrefix(3)
+	BatchNumberKeyPrefix     = collections.NewPrefix(4)
+	TreeEntriesKeyPrefix     = collections.NewPrefix(5)
+	BatchSignaturesKeyPrefix = collections.NewPrefix(6)
+	ParamsKey                = collections.NewPrefix(7)
 )

--- a/x/batching/types/query.pb.go
+++ b/x/batching/types/query.pb.go
@@ -471,6 +471,186 @@ func (m *QueryBatchSignaturesResponse) GetBatchSigs() []BatchSignatures {
 	return nil
 }
 
+// The request message for QueryDataResult RPC.
+type QueryDataResultRequest struct {
+	DataRequestId string `protobuf:"bytes,1,opt,name=data_request_id,json=dataRequestId,proto3" json:"data_request_id,omitempty"`
+}
+
+func (m *QueryDataResultRequest) Reset()         { *m = QueryDataResultRequest{} }
+func (m *QueryDataResultRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryDataResultRequest) ProtoMessage()    {}
+func (*QueryDataResultRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_351236f6b51194e8, []int{10}
+}
+func (m *QueryDataResultRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryDataResultRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryDataResultRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryDataResultRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryDataResultRequest.Merge(m, src)
+}
+func (m *QueryDataResultRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryDataResultRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryDataResultRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryDataResultRequest proto.InternalMessageInfo
+
+func (m *QueryDataResultRequest) GetDataRequestId() string {
+	if m != nil {
+		return m.DataRequestId
+	}
+	return ""
+}
+
+// The response message for QueryDataResult RPC.
+type QueryDataResultResponse struct {
+	DataResult DataResult `protobuf:"bytes,1,opt,name=data_result,json=dataResult,proto3" json:"data_result"`
+}
+
+func (m *QueryDataResultResponse) Reset()         { *m = QueryDataResultResponse{} }
+func (m *QueryDataResultResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryDataResultResponse) ProtoMessage()    {}
+func (*QueryDataResultResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_351236f6b51194e8, []int{11}
+}
+func (m *QueryDataResultResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryDataResultResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryDataResultResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryDataResultResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryDataResultResponse.Merge(m, src)
+}
+func (m *QueryDataResultResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryDataResultResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryDataResultResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryDataResultResponse proto.InternalMessageInfo
+
+func (m *QueryDataResultResponse) GetDataResult() DataResult {
+	if m != nil {
+		return m.DataResult
+	}
+	return DataResult{}
+}
+
+// The request message for QueryBatchAssignment RPC.
+type QueryBatchAssignmentRequest struct {
+	DataRequestId string `protobuf:"bytes,1,opt,name=data_request_id,json=dataRequestId,proto3" json:"data_request_id,omitempty"`
+}
+
+func (m *QueryBatchAssignmentRequest) Reset()         { *m = QueryBatchAssignmentRequest{} }
+func (m *QueryBatchAssignmentRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryBatchAssignmentRequest) ProtoMessage()    {}
+func (*QueryBatchAssignmentRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_351236f6b51194e8, []int{12}
+}
+func (m *QueryBatchAssignmentRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryBatchAssignmentRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryBatchAssignmentRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryBatchAssignmentRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryBatchAssignmentRequest.Merge(m, src)
+}
+func (m *QueryBatchAssignmentRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryBatchAssignmentRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryBatchAssignmentRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryBatchAssignmentRequest proto.InternalMessageInfo
+
+func (m *QueryBatchAssignmentRequest) GetDataRequestId() string {
+	if m != nil {
+		return m.DataRequestId
+	}
+	return ""
+}
+
+// The response message for QueryBatchAssignment RPC.
+type QueryBatchAssignmentResponse struct {
+	BatchNumber uint64 `protobuf:"varint,1,opt,name=batch_number,json=batchNumber,proto3" json:"batch_number,omitempty"`
+}
+
+func (m *QueryBatchAssignmentResponse) Reset()         { *m = QueryBatchAssignmentResponse{} }
+func (m *QueryBatchAssignmentResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryBatchAssignmentResponse) ProtoMessage()    {}
+func (*QueryBatchAssignmentResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_351236f6b51194e8, []int{13}
+}
+func (m *QueryBatchAssignmentResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryBatchAssignmentResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryBatchAssignmentResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryBatchAssignmentResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryBatchAssignmentResponse.Merge(m, src)
+}
+func (m *QueryBatchAssignmentResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryBatchAssignmentResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryBatchAssignmentResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryBatchAssignmentResponse proto.InternalMessageInfo
+
+func (m *QueryBatchAssignmentResponse) GetBatchNumber() uint64 {
+	if m != nil {
+		return m.BatchNumber
+	}
+	return 0
+}
+
 func init() {
 	proto.RegisterType((*QueryBatchRequest)(nil), "sedachain.batching.v1.QueryBatchRequest")
 	proto.RegisterType((*QueryBatchResponse)(nil), "sedachain.batching.v1.QueryBatchResponse")
@@ -482,50 +662,63 @@ func init() {
 	proto.RegisterType((*QueryTreeEntriesResponse)(nil), "sedachain.batching.v1.QueryTreeEntriesResponse")
 	proto.RegisterType((*QueryBatchSignaturesRequest)(nil), "sedachain.batching.v1.QueryBatchSignaturesRequest")
 	proto.RegisterType((*QueryBatchSignaturesResponse)(nil), "sedachain.batching.v1.QueryBatchSignaturesResponse")
+	proto.RegisterType((*QueryDataResultRequest)(nil), "sedachain.batching.v1.QueryDataResultRequest")
+	proto.RegisterType((*QueryDataResultResponse)(nil), "sedachain.batching.v1.QueryDataResultResponse")
+	proto.RegisterType((*QueryBatchAssignmentRequest)(nil), "sedachain.batching.v1.QueryBatchAssignmentRequest")
+	proto.RegisterType((*QueryBatchAssignmentResponse)(nil), "sedachain.batching.v1.QueryBatchAssignmentResponse")
 }
 
 func init() { proto.RegisterFile("sedachain/batching/v1/query.proto", fileDescriptor_351236f6b51194e8) }
 
 var fileDescriptor_351236f6b51194e8 = []byte{
-	// 600 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x95, 0xcf, 0x6b, 0x13, 0x41,
-	0x14, 0xc7, 0x33, 0xf6, 0x47, 0xf0, 0x45, 0x14, 0xc7, 0x16, 0xc3, 0x1a, 0xd6, 0x76, 0x29, 0xd2,
-	0x5a, 0xdc, 0x31, 0x89, 0x94, 0x1e, 0x02, 0x4a, 0x40, 0x11, 0xc4, 0x82, 0xb1, 0x20, 0x78, 0x30,
-	0xec, 0xc6, 0x71, 0xb3, 0x34, 0xdd, 0x49, 0x77, 0x26, 0xc5, 0x52, 0x7a, 0xf1, 0xe4, 0x4d, 0xc1,
-	0x7f, 0xc2, 0x7f, 0x40, 0xf0, 0xec, 0xa9, 0xc7, 0x82, 0x17, 0x4f, 0x22, 0x89, 0x7f, 0x88, 0xe4,
-	0xed, 0x24, 0xd9, 0xe6, 0x47, 0xb3, 0xc1, 0xdb, 0xf2, 0xfa, 0xfd, 0x7e, 0xdf, 0xa7, 0x6f, 0xde,
-	0x23, 0xb0, 0x2a, 0xf9, 0x5b, 0xa7, 0x56, 0x77, 0xfc, 0x80, 0xb9, 0x8e, 0xaa, 0xd5, 0xfd, 0xc0,
-	0x63, 0x87, 0x79, 0x76, 0xd0, 0xe2, 0xe1, 0x91, 0xdd, 0x0c, 0x85, 0x12, 0x74, 0xb9, 0x2f, 0xb1,
-	0x7b, 0x12, 0xfb, 0x30, 0x6f, 0x2c, 0x79, 0xc2, 0x13, 0xa8, 0x60, 0xdd, 0xaf, 0x48, 0x6c, 0xe4,
-	0x3c, 0x21, 0xbc, 0x06, 0x67, 0x4e, 0xd3, 0x67, 0x4e, 0x10, 0x08, 0xe5, 0x28, 0x5f, 0x04, 0x52,
-	0xff, 0x75, 0x6d, 0x7c, 0xb7, 0x7e, 0x2c, 0xaa, 0xac, 0x2d, 0xb8, 0xfe, 0xa2, 0xdb, 0xbf, 0xdc,
-	0x2d, 0x57, 0xf8, 0x41, 0x8b, 0x4b, 0x45, 0x57, 0xe1, 0x0a, 0xca, 0xaa, 0x41, 0x6b, 0xdf, 0xe5,
-	0x61, 0x96, 0xac, 0x90, 0xf5, 0xf9, 0x4a, 0x06, 0x6b, 0x3b, 0x58, 0xb2, 0x76, 0x80, 0xc6, 0x7d,
-	0xb2, 0x29, 0x02, 0xc9, 0xe9, 0x36, 0x2c, 0xa0, 0x08, 0x1d, 0x99, 0x42, 0xce, 0x1e, 0xfb, 0xef,
-	0xd8, 0x68, 0x2a, 0xcf, 0x9f, 0xfe, 0xbe, 0x9d, 0xaa, 0x44, 0x06, 0xeb, 0x21, 0x18, 0x83, 0xbc,
-	0x27, 0x22, 0x7c, 0xca, 0x7d, 0xaf, 0xae, 0xe2, 0x40, 0x0d, 0x51, 0xdb, 0xab, 0xd6, 0xb1, 0x8c,
-	0xf1, 0x73, 0x95, 0x0c, 0xd6, 0x22, 0xa5, 0xf5, 0x0a, 0x6e, 0x8d, 0x0d, 0xf8, 0x6f, 0xb2, 0x65,
-	0xb8, 0x31, 0x08, 0xe6, 0x52, 0x23, 0x59, 0xbb, 0xb0, 0x74, 0xbe, 0xac, 0x1b, 0x95, 0x20, 0xed,
-	0x46, 0xa5, 0x2c, 0x59, 0x99, 0x4b, 0xd8, 0xaa, 0x67, 0xb1, 0x4a, 0x70, 0x13, 0x53, 0x77, 0x43,
-	0xce, 0x1f, 0x07, 0x2a, 0xf4, 0xfb, 0x0d, 0x93, 0x3c, 0xca, 0x1b, 0xc8, 0x8e, 0xba, 0x35, 0x57,
-	0x19, 0xd2, 0x3c, 0x2a, 0xe9, 0x11, 0x58, 0x13, 0xb8, 0x62, 0xe6, 0x1e, 0x9d, 0x36, 0x5a, 0x8f,
-	0xe2, 0x33, 0x7e, 0xe9, 0x7b, 0x81, 0xa3, 0x5a, 0xe1, 0x4c, 0x84, 0x7b, 0x90, 0x1b, 0x9f, 0xa0,
-	0x29, 0x9f, 0x01, 0x44, 0x11, 0xd2, 0xf7, 0x7a, 0x03, 0xbc, 0x73, 0xd1, 0x00, 0x07, 0x19, 0x1a,
-	0xf6, 0xb2, 0xab, 0xcb, 0xb2, 0xf0, 0x63, 0x11, 0x16, 0xb0, 0x1b, 0xfd, 0x44, 0x60, 0x01, 0xe5,
-	0x74, 0x7d, 0x42, 0xd8, 0xc8, 0x11, 0x18, 0x1b, 0x09, 0x94, 0x11, 0xb5, 0x95, 0xff, 0xf0, 0xf3,
-	0xef, 0x97, 0x4b, 0x9b, 0x74, 0x83, 0x75, 0x2d, 0xf7, 0x86, 0x8e, 0x0e, 0x3f, 0xd8, 0x71, 0x7c,
-	0x34, 0x27, 0xf4, 0x1b, 0x81, 0xab, 0xe7, 0x57, 0x95, 0xe6, 0xa7, 0x36, 0x1c, 0xbe, 0x0b, 0xa3,
-	0x30, 0x8b, 0x45, 0xc3, 0x96, 0x10, 0x76, 0x8b, 0x3e, 0x98, 0x0c, 0x5b, 0x7d, 0x27, 0x42, 0x7d,
-	0x6a, 0xec, 0x38, 0x7e, 0x78, 0x27, 0xf4, 0x23, 0x81, 0xb4, 0x5e, 0x79, 0x7a, 0x77, 0x6a, 0xf7,
-	0xfe, 0x6e, 0x18, 0x9b, 0x89, 0xb4, 0x1a, 0x71, 0x0d, 0x11, 0x4d, 0x9a, 0x9b, 0x8c, 0xc8, 0x25,
-	0xfd, 0x4a, 0x20, 0x13, 0x5b, 0x56, 0x6a, 0x5f, 0xd4, 0x62, 0xf4, 0xa0, 0x0c, 0x96, 0x58, 0xaf,
-	0xb1, 0xb6, 0x11, 0xab, 0x40, 0xef, 0x8f, 0xc5, 0x52, 0x21, 0xe7, 0x55, 0x7d, 0x29, 0xc3, 0xaf,
-	0xfd, 0x9d, 0xc0, 0xb5, 0xa1, 0x75, 0xa5, 0xd3, 0xdf, 0x6e, 0xe4, 0xc2, 0x8c, 0xe2, 0x4c, 0x9e,
-	0x19, 0x1e, 0x5c, 0xf6, 0x6d, 0x43, 0xe8, 0xe5, 0xe7, 0xa7, 0x6d, 0x93, 0x9c, 0xb5, 0x4d, 0xf2,
-	0xa7, 0x6d, 0x92, 0xcf, 0x1d, 0x33, 0x75, 0xd6, 0x31, 0x53, 0xbf, 0x3a, 0x66, 0xea, 0x75, 0xd1,
-	0xf3, 0x55, 0xbd, 0xe5, 0xda, 0x35, 0xb1, 0x8f, 0xc9, 0xf8, 0x83, 0x52, 0x13, 0x8d, 0x78, 0x9b,
-	0xf7, 0xb1, 0xf9, 0x1c, 0x35, 0xb9, 0x74, 0x17, 0x51, 0x55, 0xfc, 0x17, 0x00, 0x00, 0xff, 0xff,
-	0x6d, 0xb6, 0x91, 0xd3, 0x0c, 0x07, 0x00, 0x00,
+	// 752 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x96, 0x4f, 0x4f, 0x13, 0x5d,
+	0x14, 0xc6, 0x3b, 0x2f, 0xf0, 0x12, 0x4e, 0x55, 0xe2, 0x15, 0x94, 0x8c, 0xcd, 0x08, 0x13, 0x42,
+	0x40, 0xc2, 0x8c, 0x2d, 0x04, 0xd1, 0x90, 0x20, 0x8d, 0x18, 0x8c, 0x91, 0xc4, 0x4a, 0x62, 0xe2,
+	0xc2, 0x66, 0xda, 0x5e, 0xa7, 0x13, 0xca, 0xdc, 0x32, 0x77, 0x4a, 0x24, 0x84, 0x8d, 0x2b, 0x77,
+	0x9a, 0xf8, 0x21, 0x34, 0xee, 0x4d, 0x4c, 0xfc, 0x02, 0x2c, 0x49, 0xdc, 0xb8, 0x32, 0x86, 0xfa,
+	0x41, 0x4c, 0xcf, 0xdc, 0x4e, 0x2f, 0x9d, 0xfe, 0x99, 0xc6, 0xdd, 0x70, 0x38, 0xcf, 0x73, 0x7e,
+	0x73, 0xee, 0xdc, 0x27, 0x85, 0x19, 0x4e, 0x4b, 0x56, 0xb1, 0x6c, 0x39, 0xae, 0x59, 0xb0, 0xfc,
+	0x62, 0xd9, 0x71, 0x6d, 0xf3, 0x30, 0x6d, 0x1e, 0xd4, 0xa8, 0x77, 0x64, 0x54, 0x3d, 0xe6, 0x33,
+	0x32, 0x19, 0xb6, 0x18, 0xcd, 0x16, 0xe3, 0x30, 0xad, 0x4e, 0xd8, 0xcc, 0x66, 0xd8, 0x61, 0x36,
+	0x9e, 0x82, 0x66, 0x35, 0x65, 0x33, 0x66, 0x57, 0xa8, 0x69, 0x55, 0x1d, 0xd3, 0x72, 0x5d, 0xe6,
+	0x5b, 0xbe, 0xc3, 0x5c, 0x2e, 0xfe, 0x3b, 0xdb, 0x79, 0x5a, 0x68, 0x8b, 0x5d, 0xfa, 0x2a, 0x5c,
+	0x7d, 0xd6, 0x98, 0x9f, 0x6d, 0x94, 0x73, 0xf4, 0xa0, 0x46, 0xb9, 0x4f, 0x66, 0xe0, 0x12, 0xb6,
+	0xe5, 0xdd, 0xda, 0x7e, 0x81, 0x7a, 0x53, 0xca, 0xb4, 0x32, 0x3f, 0x9c, 0x4b, 0x62, 0x6d, 0x07,
+	0x4b, 0xfa, 0x0e, 0x10, 0x59, 0xc7, 0xab, 0xcc, 0xe5, 0x94, 0xac, 0xc1, 0x08, 0x36, 0xa1, 0x22,
+	0x99, 0x49, 0x19, 0x1d, 0x5f, 0xc7, 0x40, 0x51, 0x76, 0xf8, 0xf4, 0xd7, 0xad, 0x44, 0x2e, 0x10,
+	0xe8, 0x1b, 0xa0, 0xb6, 0xfc, 0x1e, 0x31, 0x6f, 0x9b, 0x3a, 0x76, 0xd9, 0x97, 0x81, 0x2a, 0xac,
+	0xb8, 0x97, 0x2f, 0x63, 0x19, 0xed, 0x87, 0x72, 0x49, 0xac, 0x05, 0x9d, 0xfa, 0x0b, 0xb8, 0xd9,
+	0xd1, 0xe0, 0x9f, 0xc9, 0x26, 0xe1, 0x5a, 0xcb, 0x98, 0x72, 0x81, 0xa4, 0xef, 0xc2, 0xc4, 0xc5,
+	0xb2, 0x18, 0xb4, 0x0e, 0xa3, 0x85, 0xa0, 0x34, 0xa5, 0x4c, 0x0f, 0xc5, 0x1c, 0xd5, 0x94, 0xe8,
+	0xeb, 0x70, 0x03, 0x5d, 0x77, 0x3d, 0x4a, 0xb7, 0x5c, 0xdf, 0x73, 0xc2, 0x81, 0x71, 0x0e, 0xe5,
+	0x15, 0x4c, 0x45, 0xd5, 0x82, 0x2b, 0x0b, 0xa3, 0x34, 0x28, 0x89, 0x15, 0xe8, 0x5d, 0xb8, 0x24,
+	0x71, 0x93, 0x4e, 0x08, 0xf5, 0x07, 0xf2, 0x8e, 0x9f, 0x3b, 0xb6, 0x6b, 0xf9, 0x35, 0x6f, 0x20,
+	0xc2, 0x3d, 0x48, 0x75, 0x76, 0x10, 0x94, 0x4f, 0x00, 0x02, 0x0b, 0xee, 0xd8, 0xcd, 0x05, 0xce,
+	0xf5, 0x5a, 0x60, 0xcb, 0x43, 0xc0, 0x8e, 0x15, 0x44, 0xb9, 0x81, 0x7b, 0x1d, 0x87, 0x3d, 0xb4,
+	0x7c, 0x2b, 0x47, 0x79, 0xad, 0x12, 0x7e, 0x4f, 0x73, 0x30, 0x5e, 0xb2, 0x7c, 0x2b, 0xef, 0x05,
+	0x7f, 0xe7, 0x9d, 0x12, 0xc2, 0x8e, 0xe5, 0x2e, 0x97, 0xb0, 0x17, 0xab, 0x8f, 0x4b, 0x7a, 0x51,
+	0x1c, 0x87, 0xec, 0x20, 0x48, 0xb7, 0x21, 0x29, 0x2c, 0x1a, 0x65, 0xb1, 0xd3, 0x99, 0x2e, 0xa8,
+	0x2d, 0xbd, 0xa0, 0x84, 0x52, 0x58, 0xd1, 0xb7, 0xe4, 0xad, 0x6e, 0x72, 0xee, 0xd8, 0xee, 0x3e,
+	0x75, 0x07, 0x66, 0xdd, 0x94, 0x57, 0x2b, 0xdb, 0x08, 0xe0, 0xfe, 0xa7, 0x93, 0xf9, 0x32, 0x06,
+	0x23, 0xe8, 0x41, 0xde, 0x2b, 0x30, 0x82, 0x46, 0x64, 0xbe, 0xcb, 0x2b, 0x45, 0x52, 0x43, 0x5d,
+	0x88, 0xd1, 0x19, 0xb0, 0xe8, 0xe9, 0xb7, 0x3f, 0xfe, 0x7c, 0xfc, 0x6f, 0x91, 0x2c, 0x98, 0x0d,
+	0xc9, 0x52, 0x5b, 0x4a, 0xe1, 0x83, 0x79, 0x2c, 0xd3, 0x9e, 0x90, 0xaf, 0x0a, 0x5c, 0xb9, 0x78,
+	0xb7, 0x49, 0xba, 0xef, 0xc0, 0xf6, 0x20, 0x51, 0x33, 0x83, 0x48, 0x04, 0xec, 0x3a, 0xc2, 0xae,
+	0x92, 0x95, 0xee, 0xb0, 0xf9, 0xd7, 0xcc, 0x13, 0xd9, 0x64, 0x1e, 0xcb, 0x49, 0x75, 0x42, 0xde,
+	0x29, 0x30, 0x2a, 0x32, 0x82, 0xdc, 0xee, 0x3b, 0x3d, 0xbc, 0x4c, 0xea, 0x62, 0xac, 0x5e, 0x81,
+	0x38, 0x8b, 0x88, 0x1a, 0x49, 0x75, 0x47, 0xa4, 0x9c, 0x7c, 0x56, 0x20, 0x29, 0xdd, 0x6e, 0x62,
+	0xf4, 0x1a, 0x11, 0x4d, 0x20, 0xd5, 0x8c, 0xdd, 0x2f, 0xb0, 0xd6, 0x10, 0x2b, 0x43, 0xee, 0x74,
+	0xc4, 0xf2, 0x3d, 0x4a, 0xf3, 0x22, 0x5a, 0xda, 0x4f, 0xfb, 0x9b, 0x02, 0xe3, 0x6d, 0xf7, 0x9b,
+	0xf4, 0x3f, 0xbb, 0x48, 0x24, 0xa9, 0xcb, 0x03, 0x69, 0x06, 0x38, 0x70, 0x1e, 0xca, 0xda, 0xd1,
+	0x3f, 0x29, 0x00, 0xad, 0xfb, 0x4e, 0x96, 0x7a, 0x11, 0x44, 0x92, 0x49, 0x35, 0xe2, 0xb6, 0x0b,
+	0xd6, 0xfb, 0xc8, 0xba, 0x42, 0x32, 0x1d, 0x59, 0xa5, 0x84, 0x32, 0x8f, 0xdb, 0x52, 0xe4, 0x84,
+	0x7c, 0x6f, 0x2e, 0xb9, 0x95, 0x16, 0x31, 0x96, 0x1c, 0x49, 0xa8, 0x18, 0x4b, 0x8e, 0xc6, 0x91,
+	0xbe, 0x81, 0xe0, 0xf7, 0xc8, 0xdd, 0x1e, 0x4b, 0xb6, 0x42, 0x59, 0x94, 0x3e, 0xfb, 0xf4, 0xf4,
+	0x5c, 0x53, 0xce, 0xce, 0x35, 0xe5, 0xf7, 0xb9, 0xa6, 0x7c, 0xa8, 0x6b, 0x89, 0xb3, 0xba, 0x96,
+	0xf8, 0x59, 0xd7, 0x12, 0x2f, 0x97, 0x6d, 0xc7, 0x2f, 0xd7, 0x0a, 0x46, 0x91, 0xed, 0xa3, 0x39,
+	0xfe, 0xd2, 0x29, 0xb2, 0x8a, 0x3c, 0xe9, 0x8d, 0xf4, 0x1d, 0x1e, 0x55, 0x29, 0x2f, 0xfc, 0x8f,
+	0x5d, 0xcb, 0x7f, 0x03, 0x00, 0x00, 0xff, 0xff, 0x3e, 0x4f, 0x35, 0x0a, 0xa5, 0x09, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -551,6 +744,12 @@ type QueryClient interface {
 	// BatchSignatures returns the batch signatures for the given batch
 	// and the
 	BatchSignatures(ctx context.Context, in *QueryBatchSignaturesRequest, opts ...grpc.CallOption) (*QueryBatchSignaturesResponse, error)
+	// DataResult returns a data result given its associated data request's
+	// ID.
+	DataResult(ctx context.Context, in *QueryDataResultRequest, opts ...grpc.CallOption) (*QueryDataResultResponse, error)
+	// BatchAssignment returns the batch number that a given data request
+	// has been assigned to.
+	BatchAssignment(ctx context.Context, in *QueryBatchAssignmentRequest, opts ...grpc.CallOption) (*QueryBatchAssignmentResponse, error)
 }
 
 type queryClient struct {
@@ -606,6 +805,24 @@ func (c *queryClient) BatchSignatures(ctx context.Context, in *QueryBatchSignatu
 	return out, nil
 }
 
+func (c *queryClient) DataResult(ctx context.Context, in *QueryDataResultRequest, opts ...grpc.CallOption) (*QueryDataResultResponse, error) {
+	out := new(QueryDataResultResponse)
+	err := c.cc.Invoke(ctx, "/sedachain.batching.v1.Query/DataResult", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *queryClient) BatchAssignment(ctx context.Context, in *QueryBatchAssignmentRequest, opts ...grpc.CallOption) (*QueryBatchAssignmentResponse, error) {
+	out := new(QueryBatchAssignmentResponse)
+	err := c.cc.Invoke(ctx, "/sedachain.batching.v1.Query/BatchAssignment", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Batch returns a batch given the batch number.
@@ -619,6 +836,12 @@ type QueryServer interface {
 	// BatchSignatures returns the batch signatures for the given batch
 	// and the
 	BatchSignatures(context.Context, *QueryBatchSignaturesRequest) (*QueryBatchSignaturesResponse, error)
+	// DataResult returns a data result given its associated data request's
+	// ID.
+	DataResult(context.Context, *QueryDataResultRequest) (*QueryDataResultResponse, error)
+	// BatchAssignment returns the batch number that a given data request
+	// has been assigned to.
+	BatchAssignment(context.Context, *QueryBatchAssignmentRequest) (*QueryBatchAssignmentResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -639,6 +862,12 @@ func (*UnimplementedQueryServer) TreeEntries(ctx context.Context, req *QueryTree
 }
 func (*UnimplementedQueryServer) BatchSignatures(ctx context.Context, req *QueryBatchSignaturesRequest) (*QueryBatchSignaturesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method BatchSignatures not implemented")
+}
+func (*UnimplementedQueryServer) DataResult(ctx context.Context, req *QueryDataResultRequest) (*QueryDataResultResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DataResult not implemented")
+}
+func (*UnimplementedQueryServer) BatchAssignment(ctx context.Context, req *QueryBatchAssignmentRequest) (*QueryBatchAssignmentResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BatchAssignment not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -735,6 +964,42 @@ func _Query_BatchSignatures_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_DataResult_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryDataResultRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).DataResult(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/sedachain.batching.v1.Query/DataResult",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).DataResult(ctx, req.(*QueryDataResultRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Query_BatchAssignment_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryBatchAssignmentRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).BatchAssignment(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/sedachain.batching.v1.Query/BatchAssignment",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).BatchAssignment(ctx, req.(*QueryBatchAssignmentRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "sedachain.batching.v1.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -758,6 +1023,14 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "BatchSignatures",
 			Handler:    _Query_BatchSignatures_Handler,
+		},
+		{
+			MethodName: "DataResult",
+			Handler:    _Query_DataResult_Handler,
+		},
+		{
+			MethodName: "BatchAssignment",
+			Handler:    _Query_BatchAssignment_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -1072,6 +1345,127 @@ func (m *QueryBatchSignaturesResponse) MarshalToSizedBuffer(dAtA []byte) (int, e
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryDataResultRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryDataResultRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryDataResultRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.DataRequestId) > 0 {
+		i -= len(m.DataRequestId)
+		copy(dAtA[i:], m.DataRequestId)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.DataRequestId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryDataResultResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryDataResultResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryDataResultResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.DataResult.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryBatchAssignmentRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryBatchAssignmentRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryBatchAssignmentRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.DataRequestId) > 0 {
+		i -= len(m.DataRequestId)
+		copy(dAtA[i:], m.DataRequestId)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.DataRequestId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryBatchAssignmentResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryBatchAssignmentResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryBatchAssignmentResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.BatchNumber != 0 {
+		i = encodeVarintQuery(dAtA, i, uint64(m.BatchNumber))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -1199,6 +1593,55 @@ func (m *QueryBatchSignaturesResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *QueryDataResultRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DataRequestId)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryDataResultResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.DataResult.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryBatchAssignmentRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DataRequestId)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryBatchAssignmentResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.BatchNumber != 0 {
+		n += 1 + sovQuery(uint64(m.BatchNumber))
 	}
 	return n
 }
@@ -1931,6 +2374,322 @@ func (m *QueryBatchSignaturesResponse) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryDataResultRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryDataResultRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryDataResultRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataRequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataRequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryDataResultResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryDataResultResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryDataResultResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataResult", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.DataResult.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryBatchAssignmentRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryBatchAssignmentRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryBatchAssignmentRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataRequestId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataRequestId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryBatchAssignmentResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryBatchAssignmentResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryBatchAssignmentResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BatchNumber", wireType)
+			}
+			m.BatchNumber = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.BatchNumber |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipQuery(dAtA[iNdEx:])

--- a/x/batching/types/query.pb.gw.go
+++ b/x/batching/types/query.pb.gw.go
@@ -267,6 +267,114 @@ func local_request_Query_BatchSignatures_0(ctx context.Context, marshaler runtim
 
 }
 
+func request_Query_DataResult_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryDataResultRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["data_request_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data_request_id")
+	}
+
+	protoReq.DataRequestId, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "data_request_id", err)
+	}
+
+	msg, err := client.DataResult(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_DataResult_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryDataResultRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["data_request_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data_request_id")
+	}
+
+	protoReq.DataRequestId, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "data_request_id", err)
+	}
+
+	msg, err := server.DataResult(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Query_BatchAssignment_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryBatchAssignmentRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["data_request_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data_request_id")
+	}
+
+	protoReq.DataRequestId, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "data_request_id", err)
+	}
+
+	msg, err := client.BatchAssignment(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_BatchAssignment_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryBatchAssignmentRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["data_request_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "data_request_id")
+	}
+
+	protoReq.DataRequestId, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "data_request_id", err)
+	}
+
+	msg, err := server.BatchAssignment(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -385,6 +493,52 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_BatchSignatures_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_DataResult_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_DataResult_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_DataResult_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_BatchAssignment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_BatchAssignment_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_BatchAssignment_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -529,6 +683,46 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_DataResult_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_DataResult_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_DataResult_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_BatchAssignment_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_BatchAssignment_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_BatchAssignment_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -542,6 +736,10 @@ var (
 	pattern_Query_TreeEntries_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"seda-chain", "batching", "tree_entries", "batch_number"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_BatchSignatures_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"seda-chain", "batching", "batch_signatures", "batch_number"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_DataResult_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"seda-chain", "batching", "data_result", "data_request_id"}, "", runtime.AssumeColonVerbOpt(false)))
+
+	pattern_Query_BatchAssignment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"seda-chain", "batching", "batch_assignment", "data_request_id"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
@@ -554,4 +752,8 @@ var (
 	forward_Query_TreeEntries_0 = runtime.ForwardResponseMessage
 
 	forward_Query_BatchSignatures_0 = runtime.ForwardResponseMessage
+
+	forward_Query_DataResult_0 = runtime.ForwardResponseMessage
+
+	forward_Query_BatchAssignment_0 = runtime.ForwardResponseMessage
 )

--- a/x/tally/types/filters.go
+++ b/x/tally/types/filters.go
@@ -3,9 +3,9 @@ package types
 import (
 	"bytes"
 	"encoding/binary"
-	"slices"
 
 	"golang.org/x/exp/constraints"
+	"slices"
 )
 
 type Filter interface {


### PR DESCRIPTION
## Explanation of Changes

This PR adds a new mapping from data request ID to batch number. This "batch assignment" is created when during the batching end blocker's data result tree construction.

Also adds query endpoints for a data result given the associated data request ID and for an assigned batch number given the associated data request ID.

## Related PRs and Issues

Closes: #379