### PR TITLE
Publish data result events

### DIFF
--- a/plugins/indexing/batching/module.go
+++ b/plugins/indexing/batching/module.go
@@ -1,0 +1,59 @@
+package batching
+
+import (
+	"bytes"
+
+	// "cosmossdk.io/collections"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+	batchingtypes "github.com/sedaprotocol/seda-chain/x/batching/types"
+)
+
+const StoreKey = batchingtypes.StoreKey
+
+func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+	if _, found := bytes.CutPrefix(change.Key, batchingtypes.DataResultsPrefix); found {
+		if change.Delete {
+			logger.Trace("skipping delete", "change", change)
+			return nil, nil
+		}
+
+		val, err := codec.CollValue[batchingtypes.DataResult](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ID             string `json:"result_id"`
+			DrID           string `json:"dr_id"`
+			Version        string `json:"version"`
+			BlockHeight    uint64 `json:"block_height"`
+			ExitCode       uint32 `json:"exit_code"`
+			GasUsed        uint64 `json:"gas_used"`
+			Result         []byte `json:"result"`
+			PaybackAddress string `json:"payback_address"`
+			SedaPayload    string `json:"seda_payload"`
+			Consensus      bool   `json:"consensus"`
+		}{
+			ID:             val.Id,
+			DrID:           val.DrId,
+			Version:        val.Version,
+			BlockHeight:    val.BlockHeight,
+			ExitCode:       val.ExitCode,
+			GasUsed:        val.GasUsed,
+			Result:         val.Result,
+			PaybackAddress: val.PaybackAddress,
+			SedaPayload:    val.SedaPayload,
+			Consensus:      val.Consensus,
+		}
+
+		return types.NewMessage("data-result", data, ctx), nil
+	}
+
+	logger.Trace("skipping change", "change", change)
+	return nil, nil
+}

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/auth"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/bank"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/base"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/batching"
 	dataproxy "github.com/sedaprotocol/seda-chain/plugins/indexing/data-proxy"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
 	oracleprogram "github.com/sedaprotocol/seda-chain/plugins/indexing/oracle-program"
@@ -94,6 +95,8 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 	// 	return staking.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case dataproxy.StoreKey:
 		return dataproxy.ExtractUpdate(p.block, p.cdc, p.logger, change)
+	case batching.StoreKey:
+		return batching.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case oracleprogram.StoreKey:
 		return oracleprogram.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	default:


### PR DESCRIPTION
## Motivation

Support indexing results.

## Explanation of Changes

Reimplement the struct to avoid having to deal with the `omitempty` tags on the receiving end.

## Testing

Add code in `x/tally/keeper/abci.go` that inserts a dummy result every block.

Run the chain and plugin locally with a queue emulator, messages get published with the following JSON:

```json
{
	"type": "data-result",
	"data": {
                "result_id": "74",
		"dr_id": "74",
		"version": "1",
		"block_height": 74,
		"exit_code": 0,
		"gas_used": 0,
		"result": "eyJyZXN1bHQiOiAiMSJ9",
		"payback_address": "1",
		"seda_payload": "1",
		"consensus": true
	}
}
```

## Related PRs and Issues

Closes: #371

