### PR TITLE
Skip vote extension bytes in RequestFinalizeBlock

### DIFF
--- a/plugins/indexing/base/block.go
+++ b/plugins/indexing/base/block.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -15,6 +16,13 @@ import (
 func ExtractBlockUpdate(ctx *types.BlockContext, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) (*types.Message, error) {
 	hash := strings.ToUpper(hex.EncodeToString(req.Hash))
 	txCount := len(req.Txs)
+	if txCount > 0 {
+		// Don't count extended votes as transactions
+		var extendedVotes abci.ExtendedCommitInfo
+		if err := json.Unmarshal(req.Txs[0], &extendedVotes); err == nil {
+			txCount--
+		}
+	}
 	proposerAddress, err := sdk.ConsAddressFromHex(hex.EncodeToString(req.ProposerAddress))
 	if err != nil {
 		return nil, err

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -68,7 +68,7 @@ func (p *IndexerPlugin) ListenFinalizeBlock(_ context.Context, req abci.RequestF
 	}
 	messages = append(messages, blockMessage)
 
-	txMessages, err := base.ExtractTransactionUpdates(p.block, p.cdc, req, res)
+	txMessages, err := base.ExtractTransactionUpdates(p.block, p.cdc, p.logger, req, res)
 	if err != nil {
 		p.logger.Error("Failed to extract Tx updates", "error", err)
 		return err


### PR DESCRIPTION
## Motivation

Make explorer go brrrr.

## Explanation of Changes

We'll extract the data from the store once we want to publish it so we can safely skip the bytes in the transaction parsing.

## Testing

Tested on the planet deployment, see https://planet.test.explorer.seda.xyz/pr/feat-planet/blocks. Block 100 caused the crash originally since that was the height where vote extension were enabled.

## Related PRs and Issues

N.A.