### PR TITLE
refactor(x/batching): use geth library for ECDSA signing

### DIFF
--- a/app/abci/handlers.go
+++ b/app/abci/handlers.go
@@ -336,7 +336,6 @@ func (h *Handlers) verifyBatchSignatures(ctx sdk.Context, batchID, voteExtension
 		return err
 	}
 	pubKeyBytes := crypto.FromECDSAPub(pubKeyECDSA)
-
 	hash := crypto.Keccak256Hash(batchID)
 	sigPubKey, err := crypto.Ecrecover(hash.Bytes(), voteExtension[:65])
 	if err != nil {

--- a/app/utils/seda_keys.go
+++ b/app/utils/seda_keys.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/btcsuite/btcd/btcec/v2"
-	"github.com/ethereum/go-ethereum/crypto"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	cmtcrypto "github.com/cometbft/cometbft/crypto"
@@ -168,13 +167,13 @@ func LoadSEDASigner(loadPath string) (SEDASigner, error) {
 }
 
 func (s *sedaKeys) Sign(input []byte, index SEDAKeyIndex) ([]byte, error) {
-	privKey, err := crypto.ToECDSA(s.keys[index].PrivKey.Bytes())
+	privKey, err := ethcrypto.ToECDSA(s.keys[index].PrivKey.Bytes())
 	if err != nil {
 		return nil, err
 	}
 
-	hash := crypto.Keccak256Hash(input)
-	signature, err := crypto.Sign(hash.Bytes(), privKey)
+	hash := ethcrypto.Keccak256Hash(input)
+	signature, err := ethcrypto.Sign(hash.Bytes(), privKey)
 	if err != nil {
 		return nil, err
 	}

--- a/x/batching/types/data_result.go
+++ b/x/batching/types/data_result.go
@@ -8,6 +8,12 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+const (
+	TallyExitCodeNotEnoughCommits uint32 = 200
+	TallyExitCodeNotEnoughReveals uint32 = 201
+	TallyExitCodeFailedToExecute  uint32 = 255
+)
+
 // TryHash returns a hex-encoded hash of the DataResult.
 func (dr *DataResult) TryHash() (string, error) {
 	hasher := sha3.NewLegacyKeccak256()

--- a/x/tally/keeper/abci.go
+++ b/x/tally/keeper/abci.go
@@ -95,20 +95,17 @@ func (k Keeper) ProcessTallies(ctx sdk.Context, coreContract sdk.AccAddress) err
 		var result TallyResult
 		switch {
 		case len(req.Commits) < int(req.ReplicationFactor):
-			k.Logger(ctx).Info("data request's number of commits did not meet replication factor", "request_id", req.ID)
 			dataResults[i].Result = []byte(fmt.Sprintf("need %d commits; received %d", req.ReplicationFactor, len(req.Commits)))
-			dataResults[i].ExitCode = 200
+			dataResults[i].ExitCode = batchingtypes.TallyExitCodeNotEnoughCommits
+			k.Logger(ctx).Info("data request's number of commits did not meet replication factor", "request_id", req.ID)
 		case len(req.Reveals) < int(req.ReplicationFactor):
-			k.Logger(ctx).Info("data request's number of reveals did not meet replication factor", "request_id", req.ID)
 			dataResults[i].Result = []byte(fmt.Sprintf("need %d reveals; received %d", req.ReplicationFactor, len(req.Reveals)))
-			dataResults[i].ExitCode = 201
+			dataResults[i].ExitCode = batchingtypes.TallyExitCodeNotEnoughReveals
+			k.Logger(ctx).Info("data request's number of reveals did not meet replication factor", "request_id", req.ID)
 		default:
 			result, err := k.FilterAndTally(ctx, req)
 			if err != nil {
-				// Return with exit code 255 to signify that the tally VM
-				// was not executed due to the error specified in the result
-				// field.
-				dataResults[i].ExitCode = 0xff
+				dataResults[i].ExitCode = batchingtypes.TallyExitCodeFailedToExecute
 				dataResults[i].Result = []byte(err.Error())
 				dataResults[i].Consensus = result.consensus
 			} else {
@@ -117,11 +114,8 @@ func (k Keeper) ProcessTallies(ctx sdk.Context, coreContract sdk.AccAddress) err
 				dataResults[i].Result = result.result
 				dataResults[i].Consensus = result.consensus
 			}
-			k.Logger(ctx).Info(
-				"completed tally execution",
-				"request_id", req.ID,
-				"tally_result", result,
-			)
+			k.Logger(ctx).Info("completed tally execution", "request_id", req.ID)
+			k.Logger(ctx).Debug("tally execution result", "request_id", req.ID, "tally_result", result)
 		}
 
 		dataResults[i].Id, err = dataResults[i].TryHash()


### PR DESCRIPTION
## Explanation of Changes

- Use geth library for signing so that the public key can be recovered from the signature.