### PR TITLE
fix(batching): fix issue where hash used dataRoot instead of superRoot

### DIFF
--- a/x/batching/keeper/endblock.go
+++ b/x/batching/keeper/endblock.go
@@ -112,7 +112,7 @@ func (k Keeper) ConstructBatch(ctx sdk.Context) (types.Batch, [][]byte, [][]byte
 	//nolint:gosec // G115: We shouldn't get negative block heights anyway.
 	hashContent = binary.BigEndian.AppendUint64(hashContent, uint64(ctx.BlockHeight()))
 	hashContent = append(hashContent, valRoot...)
-	hashContent = append(hashContent, dataRoot...)
+	hashContent = append(hashContent, superRoot...)
 	hashContent = append(hashContent, provingMetaDataHash...)
 
 	hasher := sha3.NewLegacyKeccak256()


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Hashes mismatch

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

Change dataRoot to superRoot in batch id calculation
