### PR TITLE
Publish core contract address

### DIFF
--- a/plugins/indexing/oracle-program/module.go
+++ b/plugins/indexing/oracle-program/module.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"time"
 
+	"cosmossdk.io/collections"
 	storetypes "cosmossdk.io/store/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -36,6 +37,19 @@ func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger,
 		}
 
 		return types.NewMessage("oracle-program", data, ctx), nil
+	} else if _, found := bytes.CutPrefix(change.Key, oracleprogramtypes.CoreContractRegistryPrefix); found {
+		val, err := collections.StringValue.Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ContractAddr string `json:"contractAddress"`
+		}{
+			ContractAddr: val,
+		}
+
+		return types.NewMessage("core-contract", data, ctx), nil
 	} else if _, found := bytes.CutPrefix(change.Key, oracleprogramtypes.ParamsPrefix); found {
 		val, err := codec.CollValue[oracleprogramtypes.Params](cdc).Decode(change.Value)
 		if err != nil {

--- a/scripts/deploy_contracts.sh
+++ b/scripts/deploy_contracts.sh
@@ -25,7 +25,7 @@ echo "Instantiating core contract on code id $CORE_CODE_ID"
 
 OUTPUT=$($BIN tx wasm-storage submit-proposal instantiate-core-contract $CORE_CODE_ID \
     '{"token":"aseda", "owner": "'$DEV_ACCOUNT'", "chain_id":"'$CHAIN_ID'" }' \
-    $(printf '%x' $CORE_CODE_ID) \
+    $(printf '%02x' $CORE_CODE_ID) \
     --admin $DEV_ACCOUNT \
     --label core$CORE_CODE_ID \
     --title 'Core Contract' --summary 'Instantiates and registers core contract' --deposit 10000000aseda \
@@ -37,7 +37,7 @@ TXHASH=$(echo "$OUTPUT" | jq -r '.txhash')
 
 sleep 10
 
-PROPOSAL_ID=$($BIN query tx $TXHASH --output json | jq '.events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value' | sed 's/^"\(.*\)"$/\1/')  
+PROPOSAL_ID="$($BIN query tx $TXHASH --output json | jq '.events[] | select(.type == "submit_proposal") | .attributes[] | select(.key == "proposal_id") | .value' | sed 's/^"\(.*\)"$/\1/')"
 $BIN tx gov vote $PROPOSAL_ID yes \
     --from $VOTE_ACCOUNT --keyring-backend test \
     --gas-prices 100000000000aseda --gas auto --gas-adjustment 1.6 \


### PR DESCRIPTION
## Motivation

Allow indexing the current core contract. Useful when we're debugging on planet/devnet.

## Explanation of Changes

N.A.

## Testing

With the local chain, plugin, and emulator setup the following message gets published when the contract is instantiated and registered:

```json
{
	"type": "core-contract",
	"data": {
		"contractAddress": "seda15yelgw73s2r48lp9x57d6h9jzh6est34zkcchvxa3q9eax2g8jxq055jcd"
	}
}
```

## Related PRs and Issues

Somewhat related to the [events update in the chain contracts](https://github.com/sedaprotocol/seda-chain-contracts/pull/226).