### PR TITLE
Handle empty message filter env variable

### DIFF
--- a/plugins/indexing/pluginaws/types.go
+++ b/plugins/indexing/pluginaws/types.go
@@ -40,8 +40,8 @@ func NewSqsClient(logger *log.Logger) (*SqsClient, error) {
 
 	allowedMessages := make([]string, 0)
 	messageFilterString, found := os.LookupEnv(messageFilterEnvName)
-	if found {
-		allowedMessages = parseMessageFilterString((messageFilterString))
+	if found && messageFilterString != "" {
+		allowedMessages = parseMessageFilterString(messageFilterString)
 	}
 
 	sess, err := NewSession()


### PR DESCRIPTION
## Motivation

An empty variable should also allow all message types to be sent.

## Explanation of Changes

N.A.

## Testing

Ran locally with `./scripts/local-setup.sh --plugin`

## Related PRs and Issues

N.A.
