### PR TITLE
Update dependency path for tallyvm version extraction

### DIFF
--- a/dockerfiles/Dockerfile.build-static
+++ b/dockerfiles/Dockerfile.build-static
@@ -32,7 +32,7 @@ RUN ARCH=x86_64 && WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | s
     sha256sum /lib/libwasmvm_muslc.$ARCH.a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$ARCH | cut -d ' ' -f 1)
 
 # Download SEDA Wasm VM static library for amd64
-RUN ARCH=x86_64 && TALLYVM_VERSION=$(go list -m github.com/sedaprotocol/seda-wasm-vm/tallyvm | sed 's/.* //') && \
+RUN ARCH=x86_64 && TALLYVM_VERSION=$(go list -m github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 | sed 's/.* //') && \
     wget https://github.com/sedaprotocol/seda-wasm-vm/releases/download/tallyvm%2F$TALLYVM_VERSION/libseda_tally_vm_muslc.$ARCH.a \
         -O /lib/libseda_tally_vm_muslc.$ARCH.a
 
@@ -62,7 +62,7 @@ RUN ARCH=aarch64 && WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v2 | 
     sha256sum /lib/libwasmvm_muslc.$ARCH.a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$ARCH | cut -d ' ' -f 1)
 
 # Download SEDA Wasm VM static library for aarch64
-RUN ARCH=aarch64 && TALLYVM_VERSION=$(go list -m github.com/sedaprotocol/seda-wasm-vm/tallyvm | sed 's/.* //') && \
+RUN ARCH=aarch64 && TALLYVM_VERSION=$(go list -m github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 | sed 's/.* //') && \
     wget https://github.com/sedaprotocol/seda-wasm-vm/releases/download/tallyvm%2F$TALLYVM_VERSION/libseda_tally_vm_muslc.$ARCH.a \
         -O /lib/libseda_tally_vm_muslc.a
 

--- a/dockerfiles/Dockerfile.static
+++ b/dockerfiles/Dockerfile.static
@@ -33,7 +33,7 @@ RUN ARCH=$(uname -m) && WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v
     sha256sum /lib/libwasmvm_muslc.$ARCH.a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$ARCH | cut -d ' ' -f 1)
 
 # Download SEDA Wasm VM static library for aarch64
-RUN ARCH=$(uname -m) && TALLYVM_VERSION=$(go list -m github.com/sedaprotocol/seda-wasm-vm/tallyvm | sed 's/.* //') && \
+RUN ARCH=$(uname -m) && TALLYVM_VERSION=$(go list -m github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 | sed 's/.* //') && \
     wget https://github.com/sedaprotocol/seda-wasm-vm/releases/download/tallyvm%2F$TALLYVM_VERSION/libseda_tally_vm_muslc.$ARCH.a \
         -O /lib/libseda_tally_vm_muslc.a
 


### PR DESCRIPTION
## Motivation

Fix issue where the CI release builds were unable to correctly determine which tallyvm version to download. 

## Explanation of Changes

N.A.

## Testing

N.A.

## Related PRs and Issues

N.A.
