### PR TITLE
Add default genesis state

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -801,7 +801,7 @@ func NewApp(
 		ibctm.AppModule{},
 		packetforward.NewAppModule(app.PacketForwardKeeper, nil),
 		wasmstorage.NewAppModule(appCodec, app.WasmStorageKeeper),
-		tally.NewAppModule(app.TallyKeeper),
+		tally.NewAppModule(appCodec, app.TallyKeeper),
 		dataproxy.NewAppModule(appCodec, app.DataProxyKeeper),
 		pubkey.NewAppModule(appCodec, app.PubKeyKeeper),
 		batching.NewAppModule(appCodec, app.BatchingKeeper),

--- a/x/batching/keeper/integration_test.go
+++ b/x/batching/keeper/integration_test.go
@@ -234,7 +234,7 @@ func initFixture(tb testing.TB) *fixture {
 	bankModule := bank.NewAppModule(cdc, bankKeeper, accountKeeper, nil)
 	stakingModule := staking.NewAppModule(cdc, stakingKeeper, accountKeeper, bankKeeper, pubKeyKeeper)
 	wasmStorageModule := wasmstorage.NewAppModule(cdc, *wasmStorageKeeper)
-	tallyModule := tally.NewAppModule(tallyKeeper)
+	tallyModule := tally.NewAppModule(cdc, tallyKeeper)
 	pubKeyModule := pubkey.NewAppModule(cdc, pubKeyKeeper)
 	batchingModule := batching.NewAppModule(cdc, batchingKeeper)
 

--- a/x/tally/keeper/integration_test.go
+++ b/x/tally/keeper/integration_test.go
@@ -225,7 +225,7 @@ func initFixture(tb testing.TB) *fixture {
 	bankModule := bank.NewAppModule(cdc, bankKeeper, accountKeeper, nil)
 	stakingModule := staking.NewAppModule(cdc, stakingKeeper, accountKeeper, bankKeeper, pubKeyKeeper)
 	wasmStorageModule := wasmstorage.NewAppModule(cdc, *wasmStorageKeeper)
-	tallyModule := tally.NewAppModule(tallyKeeper)
+	tallyModule := tally.NewAppModule(cdc, tallyKeeper)
 
 	// Upload and instantiate the SEDA contract.
 	creator := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())

--- a/x/tally/types/codec.go
+++ b/x/tally/types/codec.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/msgservice"
+)
+
+func RegisterCodec(_ *codec.LegacyAmino) {
+}
+
+func RegisterInterfaces(registry cdctypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil),
+		&MsgUpdateParams{},
+	)
+	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
+}

--- a/x/tally/types/genesis.go
+++ b/x/tally/types/genesis.go
@@ -1,0 +1,13 @@
+package types
+
+// DefaultGenesisState creates a default GenesisState object.
+func DefaultGenesisState() *GenesisState {
+	return &GenesisState{
+		Params: DefaultParams(),
+	}
+}
+
+// ValidateGenesis validates batching genesis data.
+func ValidateGenesis(state GenesisState) error {
+	return state.Params.Validate()
+}

--- a/x/tally/types/params.go
+++ b/x/tally/types/params.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
 const (
 	DefaultMaxTallyGasLimit = 300_000_000_000_000
 )
@@ -13,5 +17,8 @@ func DefaultParams() Params {
 
 // ValidateBasic performs basic validation on tally module parameters.
 func (p *Params) Validate() error {
+	if p.MaxTallyGasLimit <= 0 {
+		return sdkerrors.ErrInvalidRequest.Wrapf("max tally gas limit must be greater than 0: %d", p.MaxTallyGasLimit)
+	}
 	return nil
 }


### PR DESCRIPTION
## Motivation

Without the default genesis state the module ends up in a state where it can't retrieve the max gas limit and all tally executions will just error out. See https://planet.test.explorer.seda.xyz/data-requests/72a0a8a68247202079023a800ef69c742e73fab43dff579bd2229cb5457ca622/894 for an example error.

Also register the message server and interfaces in the app module so we can actually update the params through governance. :)

## Explanation of Changes

Implement genesis methods in the module.

## Testing

Run a local chain with code added in the tally endblock handler to print the max gas limit every block. 

```json
{"level":"info","module":"server","module":"x/tally","max_gas_limit":300000000000000,"time":"2024-12-10T15:12:24+01:00","message":"max tally gas limit"}
```

## Related PRs and Issues

N.A.
