### PR TITLE
Improve tally error handling

### DIFF
--- a/x/tally/types/errors.go
+++ b/x/tally/types/errors.go
@@ -13,4 +13,12 @@ var (
 	ErrInvalidNumberType   = errors.Register("tally", 9, "invalid number type specified")
 	ErrFilterUnexpected    = errors.Register("tally", 10, "unexpected error occurred in filter")
 	ErrInvalidSaltLength   = errors.Register("tally", 11, "salt should be 32-byte long")
+	// Errors from FilterAndTally:
+	ErrDecodingConsensusFilter = errors.Register("tally", 12, "failed to decode consensus filter")
+	ErrDecodingPaybackAddress  = errors.Register("tally", 13, "failed to decode payback address")
+	ErrApplyingFilter          = errors.Register("tally", 14, "failed to apply filter")
+	ErrFindingTallyProgram     = errors.Register("tally", 15, "failed to find tally program")
+	ErrDecodingTallyInputs     = errors.Register("tally", 16, "failed to decode tally inputs")
+	ErrConstructingTallyVMArgs = errors.Register("tally", 17, "failed to construct tally VM arguments")
+	ErrGettingMaxTallyGasLimit = errors.Register("tally", 18, "failed to get max tally gas limit")
 )


### PR DESCRIPTION
## Explanation of Changes

When an error occurs in FilterAndTally(), we now log the error details for debugging purposes and return simplified error information to be stored as part of the data results.

## Related PRs and Issues

Closes #430
