### PR TITLE
Allow all CORS requests when running locally with plugin

### DIFF
--- a/scripts/local_setup.sh
+++ b/scripts/local_setup.sh
@@ -57,6 +57,8 @@ $BIN config set client chain-id seda-1-local
 if [[ "$INDEXING_PLUGIN" = true ]]; then
     $BIN config set app streaming.abci.keys '["*"]'
     $BIN config set app streaming.abci.plugin '"abci"'
+    # Technically this is not required for the plugin, but we'll usually want it when we're running locally.
+    sed -i '' 's/cors_allowed_origins = \[\]/cors_allowed_origins = \["*"\]/' $HOME/.sedad/config/config.toml
 fi
 
 # initialize the chain


### PR DESCRIPTION
## Motivation

Make it easy to interact with a local chain through browser extensions without having to deal with HTTP proxies.

## Explanation of Changes

Rather than introducing a new flag I lumped it with the existing `--plugin` flag, as for most cases we'll want to use them in tandem. Should it turn out to be useful separately we can always move it to its own flag.

## Testing

Similar to the setup described in #442, but now we don't need a HTTP proxy and can directly point the browser extension to the local address and port.

## Related PRs and Issues

N.A.
