### PR TITLE
Allow free gas for eligible commit/reveal messages

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -1,0 +1,170 @@
+package app
+
+import (
+	"encoding/json"
+	"errors"
+
+	wasmapp "github.com/CosmWasm/wasmd/app"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	wasmstoragekeeper "github.com/sedaprotocol/seda-chain/x/wasm-storage/keeper"
+)
+
+// HandlerOptions extends the wasmapp.HandlerOptions with a WasmStorageKeeper.
+type HandlerOptions struct {
+	wasmapp.HandlerOptions
+
+	WasmStorageKeeper *wasmstoragekeeper.Keeper
+}
+
+// NewAnteHandler wraps the wasmapp.NewAnteHandler with a CommitRevealDecorator.
+// We manually prepend the decorator so we don't have to maintain the order of the decorators
+// required by CosmWasm.
+func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
+	if options.WasmStorageKeeper == nil {
+		return nil, errors.New("wasm storage keeper is required for ante builder")
+	}
+
+	wasmAnteHandler, err := wasmapp.NewAnteHandler(options.HandlerOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	commitRevealDecorator := NewCommitRevealDecorator(options.WasmStorageKeeper, options.WasmKeeper)
+
+	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+		return commitRevealDecorator.AnteHandle(ctx, tx, simulate, wasmAnteHandler)
+	}, nil
+}
+
+// Decorator which allows for free gas for eligible commit and/or reveal messages.
+type CommitRevealDecorator struct {
+	wasmStorageKeeper *wasmstoragekeeper.Keeper
+	wasmKeeper        *wasmkeeper.Keeper
+}
+
+func NewCommitRevealDecorator(wasmStorageKeeper *wasmstoragekeeper.Keeper, wasmKeeper *wasmkeeper.Keeper) *CommitRevealDecorator {
+	return &CommitRevealDecorator{wasmStorageKeeper: wasmStorageKeeper, wasmKeeper: wasmKeeper}
+}
+
+// AnteHandle checks if a transaction consists of only eligible commit or reveal messages
+// and if so, sets the min gas prices to 0.
+func (d CommitRevealDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	// Without a core contract there is no need to check for free gas
+	coreContract, err := d.wasmStorageKeeper.GetCoreContractAddr(ctx)
+	if err != nil || coreContract == nil {
+		return next(ctx, tx, simulate)
+	}
+
+	// If any message does not qualify for free gas we don't need to check further
+	for _, msg := range tx.GetMsgs() {
+		if !d.checkFreeGas(ctx, coreContract, msg) {
+			return next(ctx, tx, simulate)
+		}
+	}
+
+	// Only when all messages qualify for free gas, we set the min gas prices to 0
+	return next(ctx.WithMinGasPrices(sdk.NewDecCoins()), tx, simulate)
+}
+
+// These are the JSON messages used by the overlay when executing the contract, the chain
+// uses the same messages to query the contract.
+type CommitDataResult struct {
+	DrID       string `json:"dr_id"`
+	PublicKey  string `json:"public_key"`
+	Commitment string `json:"commitment"`
+	Proof      string `json:"proof"`
+}
+
+type RevealDataResult struct {
+	DrID      string `json:"dr_id"`
+	PublicKey string `json:"public_key"`
+}
+
+type CanExecutorCommitQuery struct {
+	CanExecutorCommit CommitDataResult `json:"can_executor_commit"`
+}
+
+type CanExecutorRevealQuery struct {
+	CanExecutorReveal RevealDataResult `json:"can_executor_reveal"`
+}
+
+func (d CommitRevealDecorator) checkFreeGas(ctx sdk.Context, coreContract sdk.AccAddress, msg sdk.Msg) bool {
+	switch msg := msg.(type) {
+	case *wasmtypes.MsgExecuteContract:
+		// Not the core contract, so we don't need to check for free gas
+		if msg.Contract != coreContract.String() {
+			return false
+		}
+
+		contractMsg, err := unmarshalMsg(msg.Msg)
+		if err != nil {
+			return false
+		}
+
+		switch contractMsg := contractMsg.(type) {
+		case CommitDataResult:
+			result, err := d.queryContract(ctx, coreContract, CanExecutorCommitQuery{CanExecutorCommit: contractMsg})
+			if err != nil {
+				return false
+			}
+
+			return result
+		case RevealDataResult:
+			result, err := d.queryContract(ctx, coreContract, CanExecutorRevealQuery{CanExecutorReveal: contractMsg})
+			if err != nil {
+				return false
+			}
+
+			return result
+		// Not a commit or reveal message, so we don't need to check for free gas
+		default:
+			return false
+		}
+	// Not an execute contract message, so we don't need to check for free gas
+	default:
+		return false
+	}
+}
+
+func (d CommitRevealDecorator) queryContract(ctx sdk.Context, coreContract sdk.AccAddress, query interface{}) (bool, error) {
+	queryBytes, err := json.Marshal(query)
+	if err != nil {
+		return false, err
+	}
+	queryRes, err := d.wasmKeeper.QuerySmart(ctx, coreContract, queryBytes)
+	if err != nil {
+		return false, err
+	}
+
+	var result bool
+	if err := json.Unmarshal(queryRes, &result); err != nil {
+		return false, err
+	}
+
+	return result, nil
+}
+
+func unmarshalMsg(msg wasmtypes.RawContractMessage) (interface{}, error) {
+	// We're only interested in the commit or reveal messages
+	var msgData struct {
+		CommitDataResult *CommitDataResult `json:"commit_data_result"`
+		RevealDataResult *RevealDataResult `json:"reveal_data_result"`
+	}
+	if err := json.Unmarshal(msg, &msgData); err != nil {
+		return nil, err
+	}
+
+	if msgData.CommitDataResult != nil {
+		return *msgData.CommitDataResult, nil
+	}
+
+	if msgData.RevealDataResult != nil {
+		return *msgData.RevealDataResult, nil
+	}
+
+	return nil, nil
+}

--- a/app/app.go
+++ b/app/app.go
@@ -970,20 +970,23 @@ func NewApp(
 	app.MountMemoryStores(memKeys)
 
 	// initialize BaseApp
-	anteHandler, err := wasmapp.NewAnteHandler(
-		wasmapp.HandlerOptions{
-			HandlerOptions: ante.HandlerOptions{
-				AccountKeeper:   app.AccountKeeper,
-				BankKeeper:      app.BankKeeper,
-				SignModeHandler: txConfig.SignModeHandler(),
-				FeegrantKeeper:  app.FeeGrantKeeper,
-				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
+	anteHandler, err := NewAnteHandler(
+		HandlerOptions{
+			HandlerOptions: wasmapp.HandlerOptions{
+				HandlerOptions: ante.HandlerOptions{
+					AccountKeeper:   app.AccountKeeper,
+					BankKeeper:      app.BankKeeper,
+					SignModeHandler: txConfig.SignModeHandler(),
+					FeegrantKeeper:  app.FeeGrantKeeper,
+					SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
+				},
+				IBCKeeper:             app.IBCKeeper,
+				WasmConfig:            &wasmConfig,
+				WasmKeeper:            &app.WasmKeeper,
+				TXCounterStoreService: runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
+				CircuitKeeper:         &app.CircuitKeeper,
 			},
-			IBCKeeper:             app.IBCKeeper,
-			WasmConfig:            &wasmConfig,
-			WasmKeeper:            &app.WasmKeeper,
-			TXCounterStoreService: runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
-			CircuitKeeper:         &app.CircuitKeeper,
+			WasmStorageKeeper: &app.WasmStorageKeeper,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## Request

I feel like this code can definitely be better, so open to suggestions on how to better split it up to make it more maintainable/testable :)

## Motivation

Executor nodes should not have to pay for performing their duties in the protocol. The antehandler verifies that all messages in a transaction are commits and/or reveals which are eligible before allowing a gas price of 0 for the transaction.

## Explanation of Changes

We're wrapping the antehandler from CosmWasm and manually prepending our antehandler as this way we don't have to maintain the decorator list ourselves.

## Testing

I'm not quite sure how we can add unit/integration tests for this as it requires a whole bunch of keepers :(

I tested it with a local chain and a contract built from https://github.com/sedaprotocol/seda-chain-contracts/commit/aa0a52f339d1bd1ddc30e6d344b4c96de12e5c33. Then I used the regular overlay to register an identity, changed the code to not set a fee amount anymore, rebuilt the overlay and started running it. After posting a DR I saw the overlay picked it up, successfully committed and revealed. :)

Example TX result of a reveal:

```json
{
	"height": "140",
	"txhash": "6A0140F0B0AD284C77A09C7050101E11E979DCFBA71946D750931F737B1BFC47",
	"codespace": "",
	"code": 0,
	"data": "122E0A2C2F636F736D7761736D2E7761736D2E76312E4D736745786563757465436F6E7472616374526573706F6E7365",
	"raw_log": "",
	"logs": [],
	"info": "",
	"gas_wanted": "1000000",
	"gas_used": "233737",
	"tx": {
		"@type": "/cosmos.tx.v1beta1.Tx",
		"body": {
			"messages": [
				{
					"@type": "/cosmwasm.wasm.v1.MsgExecuteContract",
					"sender": "seda12rype4zl8wxcgqwl237fll6hvufkgcj8kwnuah",
					"contract": "seda1h8agdyzwc7ekua7n63y5xttfnqklctylgykfcklyr2x883vylj3qfzzs7x",
					"msg": {
						"reveal_data_result": {
							"dr_id": "8c8ec29c7b1f1557b76e9e7191c1821affd1ae0366171b3c8f46c882cd75ee76",
							"reveal_body": {
								"id": "8c8ec29c7b1f1557b76e9e7191c1821affd1ae0366171b3c8f46c882cd75ee76",
								"salt": "886c779caed0e23f6d0aadc56d25d3ef8f2362550233c43e094b3174d77088e9",
								"exit_code": 1,
								"gas_used": 0,
								"reveal": "",
								"proxy_public_keys": []
							},
							"public_key": "0368e4a40f0b80b016fe03b531c8b88dadb2001874a0de29919cc27f669085a3a8",
							"proof": "0293fbd181577c2a336b8c128bcb6b3b385fefc9f4b6967c7f85baa2950f67cc31a08a5e97f179b84a769ddca4ff3fbfb865e05e7ae05f364155e5a381e30a289d20d7e5c907f5c8b54b30350ce1ee2cff",
							"stderr": [
								"Binary 139f7a8aa60159a5ce99afed281e8180348176f56827fa01d80e97a7c38d40b0 does not exist"
							],
							"stdout": []
						}
					},
					"funds": []
				}
			],
			"memo": "",
			"timeout_height": "0",
			"extension_options": [],
			"non_critical_extension_options": []
		},
		"auth_info": {
			"signer_infos": [
				{
					"public_key": {
						"@type": "/cosmos.crypto.secp256k1.PubKey",
						"key": "AyR0Wa9Qq1PJAzxCI75KAQQQYTpBDXGGWBkjy14QVDxM"
					},
					"mode_info": {
						"single": {
							"mode": "SIGN_MODE_DIRECT"
						}
					},
					"sequence": "14"
				}
			],
			"fee": {
				"amount": [
					{
						"denom": "aseda",
						"amount": "0"
					}
				],
				"gas_limit": "1000000",
				"payer": "",
				"granter": ""
			},
			"tip": null
		},
		"signatures": [
			"psrsjU6kt8VaRL3eIX/w4LnYm8JbVBiRAS23oGTtPMggy+jbZB4qvBqBug4WG6JJDt+qOPYvyYxjEAsaHGvPWg=="
		]
	},
	"timestamp": "2025-01-08T14:32:16Z",
	"events": [
           // omitted
         ]
}

```

## Related PRs and Issues

N.A.
