### PR TITLE
Allow encryption key with allow-no-encryption flag set

### DIFF
--- a/app/utils/seda_signer.go
+++ b/app/utils/seda_signer.go
@@ -45,8 +45,6 @@ func loadSEDAKeys(keyFilePath string, allowUnencrypted bool) (keys sedaKeys, err
 	encryptionKey := ReadSEDAKeyEncryptionKeyFromEnv()
 	if encryptionKey == "" && !allowUnencrypted {
 		panic(fmt.Sprintf("SEDA key encryption key is not set, set the %s environment variable or run with --%s", SEDAKeyEncryptionKeyEnvVar, FlagAllowUnencryptedSedaKeys))
-	} else if encryptionKey != "" && allowUnencrypted {
-		panic(fmt.Sprintf("SEDA key encryption key is set, but --%s flag is also set", FlagAllowUnencryptedSedaKeys))
 	}
 
 	keyFile, err := loadSEDAKeyFile(keyFilePath, encryptionKey)


### PR DESCRIPTION
## Motivation

Annoying workaround for the tempApp issue.

## Explanation of Changes

To work around the tempApp that the CLI creates and doing validation on the presence of a encryption key we forced the allow unencrypted key files flag in the tempApp call. This causes problems when you also set the encryption key as en env variable. As we can't easily know if we're in the temp App flow or the actual app we decided to skip this check for now...

## Testing

Verified that TXs failed to create locally when the env var was set before the fix, and that it works now with the fix.

## Related PRs and Issues

Fixes issue introduced in: #468 
