### PR TITLE
chore(x/tally): update endblock error handling

### DIFF
--- a/x/tally/keeper/tally_vm.go
+++ b/x/tally/keeper/tally_vm.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	TallyExitCodeNotEnoughCommits   = 200 // tally VM not executed due to not enough commits
+	TallyExitCodeInvalidRequest     = 201 // tally VM not executed due to invalid request
 	TallyExitCodeInvalidFilterInput = 253 // tally VM not executed due to invalid filter input
 	TallyExitCodeFilterError        = 254 // tally VM not executed due to filter error
 	TallyExitCodeExecError          = 255 // error while executing tally VM

--- a/x/tally/types/data_result.go
+++ b/x/tally/types/data_result.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	"fmt"
+
+	"cosmossdk.io/math"
+
+	batchingtypes "github.com/sedaprotocol/seda-chain/x/batching/types"
+)
+
+// MarkResultAsFallback marks a DataResult as a fallback result.
+// This is used when the request cannot be processed due to an error on our side, as all
+// encoding/decoding of values is done by either the contract or the chain.
+func MarkResultAsFallback(res *batchingtypes.DataResult, err error, exitCode int) {
+	gasUsed := math.NewInt(0)
+
+	res.GasUsed = &gasUsed
+	//nolint:gosec // G115: We shouldn't get negative exit codes.
+	res.ExitCode = uint32(exitCode)
+	res.Consensus = false
+	res.Result = []byte(fmt.Sprintf("unable to process request. error: %s", err.Error()))
+}


### PR DESCRIPTION
I'm the least sure about the fallback values. In the end I decided to just write the values we got from the contract to the store, instead of redoing all the encoding checks to figure out what was wrong. 

## Motivation

Main difference is that we now allow the node to panic if we are unable to write to the store. This prevents us from continuing on invalid state should something go wrong there. It should never happen due to inputs as those get validated at mutliple points throughout the code.

We also write an empty result to the store in case there are encoding/decoding errors for fields that we are in control of.

## Explanation of Changes

N.A.

## Testing

Tests still work, no panics yet as this shouldn't really happen anyway :)

## Related PRs and Issues

N.A.
