### PR TITLE
Update tallyvm to v2.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/zerolog v1.33.0
-	github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.2.1
+	github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.2.2
 	github.com/sedaprotocol/vrf-go v0.0.0-20231211075603-e5a17bb0b87c
 	github.com/spf13/cast v1.7.0
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1019,8 +1019,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/sedaprotocol/rosetta-seda v0.0.0-20240427181737-e1d7563b2529 h1:VbJcd022MkoohRyAfktHnN99Brt/4eJr01mdLqPhGaE=
 github.com/sedaprotocol/rosetta-seda v0.0.0-20240427181737-e1d7563b2529/go.mod h1:GdlDqGJN2g55PHiwYJs2bQMlL0rdlQQbauK4dcrOI6w=
-github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.2.1 h1:9jSAOHZdQlt8dWE9/TTfsSLBn+nFY45NPcVnZaV8HsI=
-github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.2.1/go.mod h1:GnPFBlYHV+AcpLcUKcxkNkfHf2CtmTSmPbHat8flDBY=
+github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.2.2 h1:pbH4edjwATZjYyt81rScdBKnNPLNV/8ZlMaDnQPOYQE=
+github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.2.2/go.mod h1:GnPFBlYHV+AcpLcUKcxkNkfHf2CtmTSmPbHat8flDBY=
 github.com/sedaprotocol/vrf-go v0.0.0-20231211075603-e5a17bb0b87c h1:PbSn7HpWeox6lqBu6Ba6YZS3On3euwn1BPz/egsnEgA=
 github.com/sedaprotocol/vrf-go v0.0.0-20231211075603-e5a17bb0b87c/go.mod h1:DEIXHk41VUzOMVbZnIApssPXtZ+2zrETDP7kJjGc1RM=
 github.com/shamaton/msgpack/v2 v2.2.0 h1:IP1m01pHwCrMa6ZccP9B3bqxEMKMSmMVAVKk54g3L/Y=


### PR DESCRIPTION
## Motivation

No longer crash on certain Oracle Programs.

## Explanation of Changes

N.A.

## Testing

Handled in the wasm-vm repository.

## Related PRs and Issues

https://github.com/sedaprotocol/seda-wasm-vm/pull/54