### PR TITLE
Detect paused core contract and print warning

### DIFF
--- a/x/tally/types/errors.go
+++ b/x/tally/types/errors.go
@@ -1,6 +1,10 @@
 package types
 
-import "cosmossdk.io/errors"
+import (
+	"strings"
+
+	"cosmossdk.io/errors"
+)
 
 var (
 	// Errors used in filter:
@@ -20,3 +24,7 @@ var (
 	ErrConstructingTallyVMArgs = errors.Register("tally", 14, "failed to construct tally VM arguments")
 	ErrGettingMaxTallyGasLimit = errors.Register("tally", 15, "failed to get max tally gas limit")
 )
+
+func IsContractPausedError(err error) bool {
+	return strings.HasPrefix(err.Error(), "Contract paused")
+}


### PR DESCRIPTION
## Motivation

Distinguish between unexpected errors when executing the expire DR message and an expected error from when the contract is paused.

## Explanation of Changes

I think there is not much else we can do apart from checking the error string.

## Testing

Built the contract from https://github.com/sedaprotocol/seda-chain-contracts/pull/257, spun up a local chain and deployed the contract using the script in this repository. Paused the contract:

```
sedad tx wasm execute seda1gj9cxtatghehj5z57seq7mge7342gzwxu6wz42l96pf3urygjjrs0hvrmh '{"pause":{}}' --from satoshi --keyring-backend test --gas auto --gas-adjustment 1.5 --gas-prices 10000000000aseda
```

Monitor logs and observed:
```
{"level":"warn","module":"server","module":"x/tally","time":"2025-01-29T11:08:33+01:00","message":"Contract is paused, skipping tally end block"}
```

## Related PRs and Issues

https://github.com/sedaprotocol/seda-chain-contracts/pull/257
