### PR TITLE
Increase burn amount with correct number in reduced payout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/x/tally/keeper/gas_meter.go
+++ b/x/tally/keeper/gas_meter.go
@@ -46,7 +46,7 @@ func (k Keeper) DistributionsFromGasMeter(ctx sdk.Context, reqID string, reqHeig
 		if gasMeter.ReducedPayout {
 			burnAmt := burnRatio.MulInt(executor.Amount).TruncateInt()
 			payoutAmt = executor.Amount.Sub(burnAmt)
-			reducedPayoutBurn = reducedPayoutBurn.Add(burnAmt.Mul(gasMeter.GasPrice()))
+			reducedPayoutBurn = reducedPayoutBurn.Add(burnAmt)
 		}
 
 		executorDist := types.NewExecutorReward(executor.PublicKey, payoutAmt, gasMeter.GasPrice())

--- a/x/tally/keeper/integration_test.go
+++ b/x/tally/keeper/integration_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"testing"
 	"time"
@@ -331,6 +332,21 @@ func initFixture(t testing.TB) *fixture {
 		wasmViewKeeper:    wasmKeeper,
 		logBuf:            buf,
 	}
+}
+
+func (f *fixture) SetDataProxyConfig(proxyPubKey string, proxyFee sdk.Coin) error {
+	pkBytes, err := hex.DecodeString(proxyPubKey)
+	if err != nil {
+		return err
+	}
+
+	err = f.dataProxyKeeper.SetDataProxyConfig(f.Context(), pkBytes,
+		dataproxytypes.ProxyConfig{
+			Fee: &proxyFee,
+		},
+	)
+
+	return err
 }
 
 var setStakingConfigMsg = `{


### PR DESCRIPTION
## Motivation

We encountered a bug on planet where a reduced payout scenario resulted in ALL funds being burnt with nothing left over for the data proxies or executors. This is not very fair.

## Explanation of Changes

No longer multiply the reduced burn amount (gas) with the gas price twice.

## Testing

Added a manual test for the exact reproduction scenario and changed the fuzz test to also do a sanity check that reduced payout only changes where funds are allocated and no increase/decrease in the total.

## Related PRs and Issues

N.A.
