### PR TITLE
Publish pubkey and tally data

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,11 +76,7 @@ linters-settings:
     skip-generated: false
   dogsled:
     max-blank-identifiers: 3
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
   nolintlint:
     allow-unused: true
-    allow-leading-space: true
     require-explanation: false
     require-specific: false

--- a/plugins/indexing/plugin.go
+++ b/plugins/indexing/plugin.go
@@ -31,6 +31,7 @@ import (
 	oracleprogram "github.com/sedaprotocol/seda-chain/plugins/indexing/oracle-program"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/pluginaws"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/pubkey"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/tally"
 	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
 )
 
@@ -102,6 +103,8 @@ func (p *IndexerPlugin) extractUpdate(change *storetypes.StoreKVPair) (*types.Me
 		return batching.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	case oracleprogram.StoreKey:
 		return oracleprogram.ExtractUpdate(p.block, p.cdc, p.logger, change)
+	case tally.StoreKey:
+		return tally.ExtractUpdate(p.block, p.cdc, p.logger, change)
 	default:
 		return nil, nil
 	}

--- a/plugins/indexing/tally/module.go
+++ b/plugins/indexing/tally/module.go
@@ -1,0 +1,43 @@
+package tally
+
+import (
+	"bytes"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/log"
+	"github.com/sedaprotocol/seda-chain/plugins/indexing/types"
+	tallytypes "github.com/sedaprotocol/seda-chain/x/tally/types"
+)
+
+const StoreKey = tallytypes.StoreKey
+
+type Params tallytypes.Params
+
+func (p Params) MarshalJSON() ([]byte, error) {
+	return types.MarshalJSJSON(p)
+}
+
+func ExtractUpdate(ctx *types.BlockContext, cdc codec.Codec, logger *log.Logger, change *storetypes.StoreKVPair) (*types.Message, error) {
+	if _, found := bytes.CutPrefix(change.Key, tallytypes.ParamsPrefix); found {
+		val, err := codec.CollValue[tallytypes.Params](cdc).Decode(change.Value)
+		if err != nil {
+			return nil, err
+		}
+
+		data := struct {
+			ModuleName string `json:"moduleName"`
+			Params     Params `json:"params"`
+		}{
+			ModuleName: "tally",
+			Params:     Params(val),
+		}
+
+		return types.NewMessage("module-params", data, ctx), nil
+	}
+
+	logger.Trace("skipping change", "change", change)
+	return nil, nil
+}

--- a/plugins/indexing/types/js_json_marshal.go
+++ b/plugins/indexing/types/js_json_marshal.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// MarshalJSJSON marshals a struct to a JSON object that can be used in JavaScript.
+// It converts all int64 and uint64 values to strings as these exceed the safe integer
+// limit for JavaScript.
+func MarshalJSJSON(p interface{}) ([]byte, error) {
+	fields := make(map[string]interface{})
+
+	// Use reflection to iterate through struct fields
+	v := reflect.ValueOf(p)
+	t := v.Type()
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		value := v.Field(i)
+
+		// Get the json tag name, or use field name if no tag
+		jsonTag := field.Tag.Get("json")
+		name := strings.Split(jsonTag, ",")[0]
+		if name == "" {
+			name = field.Name
+		}
+
+		// Convert specific types to strings
+		switch value.Kind() {
+		case reflect.Int64:
+			fields[name] = fmt.Sprintf("%d", value.Int())
+		case reflect.Uint64:
+			fields[name] = fmt.Sprintf("%d", value.Uint())
+		default:
+			fields[name] = value.Interface()
+		}
+	}
+
+	return json.Marshal(fields)
+}


### PR DESCRIPTION
## Motivation

Allow the indexer to process this data.

## Explanation of Changes

Also removed deprecated golangci lint settings so the pipeline stops yelling at me.

## Testing

The following JSON messages get published on the SQS queue:

```js
{
	type: "module-params",
	data: {
		moduleName: "tally",
		params: {
			burn_ratio: "0.200000000000000000",
			execution_gas_cost_fallback: "5000000000000",
			filter_gas_cost_multiplier_mode: "100000",
			filter_gas_cost_multiplier_std_dev: "100000",
			filter_gas_cost_none: "100000",
			gas_cost_base: "1000000000000",
			max_result_size: 1024,
			max_tallies_per_block: 100,
			max_tally_gas_limit: "50000000000000",
		},
	},
}
```

```js
{
	type: "module-params",
	data: {
		moduleName: "pubkey",
		params: {
			activation_block_delay: "11520",
			activation_threshold_percent: 80,
		},
	},
}
```

```js
{
	type: "proving-scheme",
	data: { index: 0, is_activated: false, activation_height: "11521" },
}
```

## Related PRs and Issues

Closes: #506, #507 