### PR TITLE
Basic batch signing testing through e2e test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,20 +55,6 @@ jobs:
           mkdir build
           docker run --rm -v $(pwd)/build:/output seda-static cp -r /build/. /output/
 
-      - name: 🐳 Build and Push
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./dockerfiles/Dockerfile.release
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},name-canonical=true,push=true
-          tags: ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}, ${{ env.REGISTRY_IMAGE }}:latest
-
       - name: 🪵 Conventional Changelog
         id: changelog
         uses: TriPSs/conventional-changelog-action@v5
@@ -94,3 +80,17 @@ jobs:
           generateReleaseNotes: true
           body: ${{ steps.changelog.outputs.clean_changelog }}
           artifacts: "checksum.txt,build/sedad-amd64,build/sedad-arm64"
+
+      - name: 🐳 Build and Push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./dockerfiles/Dockerfile.release
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},name-canonical=true,push=true
+          tags: ${{ env.REGISTRY_IMAGE }}:${{ github.ref_name }}, ${{ env.REGISTRY_IMAGE }}:latest

--- a/e2e/chain.go
+++ b/e2e/chain.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
 
 	"github.com/sedaprotocol/seda-chain/app"
@@ -41,10 +42,12 @@ func init() {
 }
 
 type chain struct {
-	dataDir         string
-	id              string
-	validators      []*validator
-	genesisAccounts []*account // initial accounts in genesis
+	dataDir          string
+	id               string
+	validators       []*validator
+	genesisAccounts  []*account // initial accounts in genesis
+	deployer         *account
+	coreContractAddr sdk.AccAddress
 }
 
 func newChain() (*chain, error) {

--- a/e2e/e2e_setup_test.go
+++ b/e2e/e2e_setup_test.go
@@ -30,6 +30,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+
+	pubkeytypes "github.com/sedaprotocol/seda-chain/x/pubkey/types"
 )
 
 const (
@@ -152,6 +154,7 @@ func (s *IntegrationTestSuite) initNodes(c *chain) {
 		s.Require().NoError(err)
 		addrAll = append(addrAll, acctAddr)
 	}
+	c.deployer = c.genesisAccounts[len(c.genesisAccounts)-1]
 
 	err = modifyGenesis(val0ConfigDir, "", initBalanceStr, addrAll, initialGlobalFeeAmt+asedaDenom, asedaDenom)
 	s.Require().NoError(err)
@@ -225,11 +228,16 @@ func (s *IntegrationTestSuite) initGenesis(c *chain) {
 	appGenState[genutiltypes.ModuleName], err = cdc.MarshalJSON(&genUtilGenState)
 	s.Require().NoError(err)
 
+	pubKeyGenState := pubkeytypes.DefaultGenesisState()
+	pubKeyGenState.Params.ActivationBlockDelay = 1
+	appGenState[pubkeytypes.ModuleName], err = cdc.MarshalJSON(pubKeyGenState)
+	s.Require().NoError(err)
+
 	appGenesis.AppState, err = json.MarshalIndent(appGenState, "", "  ")
 	s.Require().NoError(err)
 
-	// Disable vote extensions in e2e testing.
-	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = 10000
+	// Enable vote extensions in e2e testing
+	appGenesis.Consensus.Params.ABCI.VoteExtensionsEnableHeight = 1
 
 	err = genutil.ExportGenesisFile(appGenesis, genFilePath)
 	s.Require().NoError(err)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,6 +1,9 @@
 package e2e
 
-var runWasmStorageTest = true
+var (
+	runWasmStorageTest = true
+	runBatchingTest    = true
+)
 
 func (s *IntegrationTestSuite) TestWasmStorage() {
 	if !runWasmStorageTest {
@@ -8,4 +11,11 @@ func (s *IntegrationTestSuite) TestWasmStorage() {
 	}
 	s.testWasmStorageStoreOracleProgram()
 	s.testInstantiateCoreContract() // involves gov process
+}
+
+func (s *IntegrationTestSuite) TestBatching() {
+	if !runBatchingTest {
+		s.T().Skip()
+	}
+	s.testUnbond() // to trigger batch creation and signing
 }

--- a/e2e/e2e_unbond_test.go
+++ b/e2e/e2e_unbond_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+func (s *IntegrationTestSuite) testUnbond() {
+	s.Run("unbond", func() {
+		val1Addr, err := s.chain.validators[0].keyInfo.GetAddress()
+		s.Require().NoError(err)
+		val1 := val1Addr.String()
+
+		val2Addr, err := s.chain.validators[1].keyInfo.GetAddress()
+		s.Require().NoError(err)
+		val2 := val2Addr.String()
+
+		s.execUnbond(s.chain, 0, sdk.ValAddress(val1Addr), val1, standardFees.String(), false)
+		s.Require().Eventually(
+			func() bool {
+				batch, err := queryBatch(s.endpoint, 2)
+				if err != nil {
+					return false
+				}
+				return len(batch.BatchSignatures) == len(s.chain.validators)
+			},
+			30*time.Second,
+			5*time.Second,
+		)
+
+		s.execUnbond(s.chain, 1, sdk.ValAddress(val2Addr), val2, standardFees.String(), false)
+		s.Require().Eventually(
+			func() bool {
+				batch, err := queryBatch(s.endpoint, 3)
+				if err != nil {
+					return false
+				}
+
+				if len(batch.BatchSignatures) != len(s.chain.validators) {
+					return false
+				}
+				for _, sig := range batch.BatchSignatures {
+					if len(sig.Secp256K1Signature) != 65 {
+						return false
+					}
+					if sig.ValidatorAddress.Empty() {
+						return false
+					}
+				}
+				return true
+			},
+			90*time.Second,
+			5*time.Second,
+		)
+	})
+}
+
+func (s *IntegrationTestSuite) execUnbond(
+	c *chain,
+	valIdx int,
+	valAddr sdktypes.ValAddress,
+	from string,
+	fees string,
+	expectErr bool,
+	opt ...flagOption,
+) {
+	opt = append(opt, withKeyValue(flagFees, fees))
+	opt = append(opt, withKeyValue(flagFrom, from))
+	opts := applyTxOptions(c.id, opt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	command := []string{
+		binary,
+		txCommand,
+		stakingtypes.ModuleName,
+		"unbond",
+		valAddr.String(),
+		"1aseda",
+		"-y",
+	}
+	for flag, value := range opts {
+		command = append(command, fmt.Sprintf("--%s=%v", flag, value))
+	}
+
+	s.T().Logf("unbond tx to trigger batch creation on chain %s", c.id)
+
+	s.executeTx(ctx, c, command, valIdx, s.expectErrExecValidation(c, valIdx, expectErr))
+}


### PR DESCRIPTION
Since simulation testing does not involve the ABCI consensus process, we need to resort to the e2e test to test the complete sequence of ABCI methods we use for batch signing.
This PR adds two unbond transactions to the e2e to trigger creation of batches. The test waits until the number of signatures collected for each batch equals to the number of validators.