### PR TITLE
Update local multi setup

### DIFF
--- a/scripts/local_setup.sh
+++ b/scripts/local_setup.sh
@@ -69,6 +69,7 @@ cat $HOME/.sedad/config/genesis.json | jq '.app_state["gov"]["params"]["voting_p
 cat $HOME/.sedad/config/genesis.json | jq '.app_state["gov"]["params"]["expedited_voting_period"]="15s"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
 cat $HOME/.sedad/config/genesis.json | jq '.consensus.params.block.max_gas="100000000"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
 cat $HOME/.sedad/config/genesis.json | jq '.consensus.params.abci.vote_extensions_enable_height = "10"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
+cat $HOME/.sedad/config/genesis.json | jq '.app_state["pubkey"]["params"]["activation_block_delay"]="25"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     sed -i '' 's/swagger = false/swagger = true/' $HOME/.sedad/config/app.toml


### PR DESCRIPTION
## Motivation

Make it easier to locally test a multi validator network setup.

## Explanation of Changes

Fixes overlapping ports and makes the genesis file more similar to what we use in the single node setup.

## Testing

Run the script locally and check that all the validators get created and batches are created and signed.

## Related PRs and Issues

N.A.
