### PR TITLE
Add e2e test for batch signing when 1/3rd of voting power rotates keys

### DIFF
--- a/e2e/e2e_batch_key_rotation_test.go
+++ b/e2e/e2e_batch_key_rotation_test.go
@@ -1,0 +1,119 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	pubkeytypes "github.com/sedaprotocol/seda-chain/x/pubkey/types"
+)
+
+func (s *IntegrationTestSuite) testBatchKeyRotation() {
+	s.Run("batch key rotation", func() {
+		val1Addr, err := s.chain.validators[0].keyInfo.GetAddress()
+		s.Require().NoError(err)
+		val1 := val1Addr.String()
+
+		// Get currently registered pubkeyBefore of validator 1
+		var val1OperatorAddr sdk.ValAddress
+		val1OperatorAddr = val1Addr.Bytes()
+		pubkeyBefore, err := queryPubkey(s.endpoint, val1OperatorAddr.String())
+		s.Require().NoError(err)
+
+		// Get the latest batch before rotation
+		batchBefore, err := queryLatestBatch(s.endpoint)
+		s.Require().NoError(err)
+
+		s.T().Logf("Batch number before rotation: %v", batchBefore.Batch.BatchNumber)
+
+		var ethAddrBefore []byte
+		for _, entry := range batchBefore.ValidatorEntries {
+			if entry.ValidatorAddress.Equals(val1Addr) {
+				ethAddrBefore = entry.EthAddress
+				break
+			}
+		}
+		s.Require().NotNil(ethAddrBefore)
+
+		// Rotate key of validator 1
+		s.execBatchKeyRotation(s.chain, 0, val1, standardFees.String(), false)
+		s.Require().Eventually(
+			func() bool {
+				batch, err := queryBatch(s.endpoint, batchBefore.Batch.BatchNumber+1)
+				if err != nil {
+					s.T().Logf("Error querying batch: %v", err)
+					return false
+				}
+				for _, entry := range batch.ValidatorEntries {
+					if entry.ValidatorAddress.Equals(val1Addr) {
+						ethAddrChanged := !bytes.Equal(entry.EthAddress, ethAddrBefore)
+						s.T().Logf("Validator 1 eth address changed: %v", ethAddrChanged)
+						return ethAddrChanged
+					}
+				}
+				// Didn't find validator 1 in the batch
+				s.T().Logf("Validator 1 not found in batch %v", batch.Batch.BatchNumber+1)
+				return false
+			},
+			30*time.Second,
+			5*time.Second,
+		)
+
+		// Verify pubkey of validator 1 is rotated in registry
+		pubkeyAfter, err := queryPubkey(s.endpoint, val1OperatorAddr.String())
+		s.Require().NoError(err)
+		s.Require().NotEqual(pubkeyBefore.ValidatorPubKeys.IndexedPubKeys[0].PubKey, pubkeyAfter.ValidatorPubKeys.IndexedPubKeys[0].PubKey)
+
+		// Trigger new batch creation and verify that it is signed
+		s.execUnbond(s.chain, 0, sdk.ValAddress(val1Addr), val1, standardFees.String(), false)
+		s.Require().Eventually(
+			func() bool {
+				batch, err := queryBatch(s.endpoint, batchBefore.Batch.BatchNumber+2)
+				if err != nil {
+					s.T().Logf("Error querying batch: %v", err)
+					return false
+				}
+				s.T().Logf("Batch signatures: %v, expected: %v", len(batch.BatchSignatures), len(s.chain.validators))
+				return len(batch.BatchSignatures) == len(s.chain.validators)
+			},
+			30*time.Second,
+			5*time.Second,
+		)
+	})
+}
+
+func (s *IntegrationTestSuite) execBatchKeyRotation(
+	c *chain,
+	valIdx int,
+	from string,
+	fees string,
+	expectErr bool,
+	opt ...flagOption,
+) {
+	opt = append(opt, withKeyValue(flagFees, fees))
+	opt = append(opt, withKeyValue(flagFrom, from))
+	opts := applyTxOptions(c.id, opt)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	command := []string{
+		binary,
+		txCommand,
+		pubkeytypes.ModuleName,
+		"add-seda-keys",
+		"-y",
+		"--key-file-force",
+		"--key-file-no-encryption",
+	}
+	for flag, value := range opts {
+		command = append(command, fmt.Sprintf("--%s=%v", flag, value))
+	}
+
+	s.T().Logf("add-seda-keys tx to rotate batch signing key on chain %s", c.id)
+
+	s.executeTx(ctx, c, command, valIdx, s.expectErrExecValidation(c, valIdx, expectErr))
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,7 +1,7 @@
 package e2e
 
 var (
-	runWasmStorageTest = true
+	runWasmStorageTest = false
 	runBatchingTest    = true
 )
 
@@ -17,5 +17,6 @@ func (s *IntegrationTestSuite) TestBatching() {
 	if !runBatchingTest {
 		s.T().Skip()
 	}
-	s.testUnbond() // to trigger batch creation and signing
+	s.testUnbond()           // to trigger batch creation and signing, and ensuring there are batches for the rotation test
+	s.testBatchKeyRotation() // to verify that when > 1/3 of the voting power rotates the signing process continues as expected
 }

--- a/e2e/e2e_unbond_test.go
+++ b/e2e/e2e_unbond_test.go
@@ -1,13 +1,16 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	batchingtypes "github.com/sedaprotocol/seda-chain/x/batching/types"
 )
 
 func (s *IntegrationTestSuite) testUnbond() {
@@ -20,10 +23,20 @@ func (s *IntegrationTestSuite) testUnbond() {
 		s.Require().NoError(err)
 		val2 := val2Addr.String()
 
+		// Ensure that only the first batch is created
+		firstBatch, err := queryBatch(s.endpoint, 0)
+		s.Require().NoError(err)
+		_, err = queryBatch(s.endpoint, 1)
+		s.Require().Error(err)
+
+		validatorEntriesBefore := firstBatch.ValidatorEntries
+		slices.SortFunc(validatorEntriesBefore, sortValidatorEntries)
+		s.T().Logf("validatorEntriesBefore: %v", validatorEntriesBefore)
+
 		s.execUnbond(s.chain, 0, sdk.ValAddress(val1Addr), val1, standardFees.String(), false)
 		s.Require().Eventually(
 			func() bool {
-				batch, err := queryBatch(s.endpoint, 1)
+				batch, err := queryBatch(s.endpoint, firstBatch.Batch.BatchNumber+1)
 				if err != nil {
 					return false
 				}
@@ -32,6 +45,24 @@ func (s *IntegrationTestSuite) testUnbond() {
 			30*time.Second,
 			5*time.Second,
 		)
+
+		batchMiddle, err := queryBatch(s.endpoint, firstBatch.Batch.BatchNumber+1)
+		s.Require().NoError(err)
+		validatorEntriesMiddle := batchMiddle.ValidatorEntries
+		slices.SortFunc(validatorEntriesMiddle, sortValidatorEntries)
+		s.T().Logf("validatorEntriesMiddle: %v", validatorEntriesMiddle)
+
+		for i, entry := range validatorEntriesBefore {
+			s.Require().Equal(entry.ValidatorAddress, validatorEntriesMiddle[i].ValidatorAddress)
+
+			// Due to the small amount being unbonded only the first validator should have had their voting power change: 50.000000% -> 49.999999%
+			// The other validator should have had their voting power remain the same: 50.000000% -> 50.000000%
+			if entry.ValidatorAddress.Equals(val1Addr) {
+				s.Require().NotEqual(entry.VotingPowerPercent, validatorEntriesMiddle[i].VotingPowerPercent, "Voting power percent should have changed %d", entry.VotingPowerPercent)
+			} else {
+				s.Require().Equal(entry.VotingPowerPercent, validatorEntriesMiddle[i].VotingPowerPercent, "Voting power percent should not have changed %d", entry.VotingPowerPercent)
+			}
+		}
 
 		s.execUnbond(s.chain, 1, sdk.ValAddress(val2Addr), val2, standardFees.String(), false)
 		s.Require().Eventually(
@@ -57,7 +88,22 @@ func (s *IntegrationTestSuite) testUnbond() {
 			90*time.Second,
 			5*time.Second,
 		)
+
+		batchAfter, err := queryBatch(s.endpoint, batchMiddle.Batch.BatchNumber+1)
+		s.Require().NoError(err)
+		validatorEntriesAfter := batchAfter.ValidatorEntries
+		slices.SortFunc(validatorEntriesAfter, sortValidatorEntries)
+		s.T().Logf("validatorEntriesAfter: %v", validatorEntriesAfter)
+
+		for i, entry := range validatorEntriesBefore {
+			s.Require().Equal(entry.ValidatorAddress, validatorEntriesAfter[i].ValidatorAddress)
+			s.Require().Equal(entry.VotingPowerPercent, validatorEntriesAfter[i].VotingPowerPercent, "Voting power percent should not have changed %d", entry.VotingPowerPercent)
+		}
 	})
+}
+
+func sortValidatorEntries(a, b batchingtypes.ValidatorTreeEntry) int {
+	return bytes.Compare(a.ValidatorAddress, b.ValidatorAddress)
 }
 
 func (s *IntegrationTestSuite) execUnbond(
@@ -82,7 +128,7 @@ func (s *IntegrationTestSuite) execUnbond(
 		stakingtypes.ModuleName,
 		"unbond",
 		valAddr.String(),
-		"1aseda",
+		"1seda",
 		"-y",
 	}
 	for flag, value := range opts {

--- a/e2e/query.go
+++ b/e2e/query.go
@@ -8,6 +8,7 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 
 	batchingtypes "github.com/sedaprotocol/seda-chain/x/batching/types"
+	pubkeytypes "github.com/sedaprotocol/seda-chain/x/pubkey/types"
 	wasmstoragetypes "github.com/sedaprotocol/seda-chain/x/wasm-storage/types"
 )
 
@@ -49,6 +50,30 @@ func queryGovProposal(endpoint string, proposalID int) (govtypes.QueryProposalRe
 func queryBatch(endpoint string, batchNumber uint64) (batchingtypes.QueryBatchResponse, error) {
 	var res batchingtypes.QueryBatchResponse
 	body, err := httpGet(fmt.Sprintf("%s/seda-chain/batching/batch/%s", endpoint, fmt.Sprintf("%d", batchNumber)))
+	if err != nil {
+		return res, err
+	}
+	if err = cdc.UnmarshalJSON(body, &res); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func queryLatestBatch(endpoint string) (batchingtypes.QueryBatchResponse, error) {
+	var res batchingtypes.QueryBatchResponse
+	body, err := httpGet(fmt.Sprintf("%s/seda-chain/batching/batch/0?latest_signed=1", endpoint))
+	if err != nil {
+		return res, err
+	}
+	if err = cdc.UnmarshalJSON(body, &res); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func queryPubkey(endpoint string, validatorAddress string) (pubkeytypes.QueryValidatorKeysResponse, error) {
+	var res pubkeytypes.QueryValidatorKeysResponse
+	body, err := httpGet(fmt.Sprintf("%s/seda-chain/pubkey/validator_keys/%s", endpoint, validatorAddress))
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
## Motivation

This adds a test that hopefully confirms our implementation is correct for the batch signing key rotation.

## Explanation of Changes

Test in a 2 validator network with both validators starting at 50% voting power.
Record the eth address of validator 1.
Rotate the key of validator 1.
Confirm a new batch is created and that it has a new eth address for validator 1.
Trigger a new batch creation.
Confirm that this new batch is signed by both validators.

This test does not guarantee that the signature verification is implemented correctly, but in the case that it is it proves that a validator correctly signs the batch after rotation with their **old** key, and only the next batches get signed with the **new** key.

## Testing

It's just a test.

## Related PRs and Issues

Targeting other PR to simplify merging.
