### PR TITLE
Use SenderNonceMempool

### DIFF
--- a/app/abci/testutil/tx_verifier_mock.go
+++ b/app/abci/testutil/tx_verifier_mock.go
@@ -1,0 +1,111 @@
+package testutil
+
+import (
+	"reflect"
+
+	gomock "go.uber.org/mock/gomock"
+	protov2 "google.golang.org/protobuf/proto"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var (
+	ValidTx   = []byte("valid")
+	InvalidTx = []byte("invalid")
+	LargeTx   = []byte("large")
+)
+
+type MockTx struct {
+	gas uint64
+}
+
+func (m *MockTx) GetMsgs() []sdk.Msg {
+	return []sdk.Msg{}
+}
+
+func (m *MockTx) GetMsgsV2() ([]protov2.Message, error) {
+	return []protov2.Message{}, nil
+}
+
+func (m *MockTx) GetGas() uint64 {
+	return m.gas
+}
+
+func NewMockTx(gas uint64) *MockTx {
+	return &MockTx{gas: gas}
+}
+
+// MockSEDASigner is a mock of SEDASigner interface.
+type MockTxVerifier struct {
+	ctrl     *gomock.Controller
+	recorder *MockTxVerifierMockRecorder
+}
+
+// MockTxVerifierMockRecorder is the mock recorder for MockSEDASigner.
+type MockTxVerifierMockRecorder struct {
+	mock *MockTxVerifier
+}
+
+// NewMockSEDASigner creates a new mock instance.
+func NewMockTxVerifier(ctrl *gomock.Controller) *MockTxVerifier {
+	mock := &MockTxVerifier{ctrl: ctrl}
+	mock.recorder = &MockTxVerifierMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTxVerifier) EXPECT() *MockTxVerifierMockRecorder {
+	return m.recorder
+}
+
+func (m *MockTxVerifier) PrepareProposalVerifyTx(tx sdk.Tx) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareProposalVerifyTx", tx)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockTxVerifierMockRecorder) PrepareProposalVerifyTx(input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareProposalVerifyTx", reflect.TypeOf((*MockTxVerifier)(nil).PrepareProposalVerifyTx), input)
+}
+
+func (m *MockTxVerifier) ProcessProposalVerifyTx(txBz []byte) (sdk.Tx, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ProcessProposalVerifyTx", txBz)
+	ret0, _ := ret[0].(sdk.Tx)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockTxVerifierMockRecorder) ProcessProposalVerifyTx(input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessProposalVerifyTx", reflect.TypeOf((*MockTxVerifier)(nil).ProcessProposalVerifyTx), input)
+}
+
+func (m *MockTxVerifier) TxDecode(txBz []byte) (sdk.Tx, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxDecode", txBz)
+	ret0, _ := ret[0].(sdk.Tx)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockTxVerifierMockRecorder) TxDecode(input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxDecode", reflect.TypeOf((*MockTxVerifier)(nil).TxDecode), input)
+}
+
+func (m *MockTxVerifier) TxEncode(tx sdk.Tx) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxEncode", tx)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockTxVerifierMockRecorder) TxEncode(input any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxEncode", reflect.TypeOf((*MockTxVerifier)(nil).TxEncode), input)
+}

--- a/app/params/config.go
+++ b/app/params/config.go
@@ -17,6 +17,8 @@ const (
 
 	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address.
 	Bech32PrefixAccAddr = "seda"
+
+	DefaultMempoolMaxTxs = 5000
 )
 
 var (

--- a/cmd/sedad/cmd/config_defaults.go
+++ b/cmd/sedad/cmd/config_defaults.go
@@ -55,6 +55,7 @@ func initAppConfig() (string, interface{}) {
 	//
 	// In simapp, we set the min gas prices to 0.
 	srvCfg.MinGasPrices = params.MinimumGasPrice.String()
+	srvCfg.Mempool.MaxTxs = params.DefaultMempoolMaxTxs
 
 	// GRPC settings
 	srvCfg.GRPC.Enable = true


### PR DESCRIPTION
## Motivation

The NoOpMempool accepts any transactions proposed by the proposer and does not do any validation, see https://github.com/cosmos/cosmos-sdk/blob/v0.50.12/baseapp/abci_utils.go#L385. By switching to a different mempool and making sure the bytes which are not valid TXs are not validated we can get the best of both worlds.

Due to an error in the default config prior to https://github.com/cosmos/cosmos-sdk/pull/20008 it seems most of our validators will have a setting for the MaxTs which results in the SenderNonceMempool being selected: https://github.com/cosmos/cosmos-sdk/blob/v0.50.12/server/util.go#L544. Looking at our testnet and mainnet nodes I can confirm that the `max-txs` attribute in the `config/app.toml` is set to `5000`

For these reasons I think we should be fine with the SenderNonceMempool, but we might want to spend a little more time researching the impact of changing mempool implementations.

## Explanation of Changes

With this mempool the default ProcessProposal handler will validate that all TXs are valid before accepting a proposal.

## Testing

Added a manual mock for the TX verifier, as this is normally handled by the baseapp.

## Related PRs and Issues

N.A.
