### PR TITLE
Consume remaining tally gas in out of gas case

### DIFF
--- a/app/abci/errors.go
+++ b/app/abci/errors.go
@@ -11,4 +11,5 @@ var (
 	ErrVoteExtensionInjectionTooBig = errors.Register(ModuleName, 5, "injected vote extensions are too big")
 	ErrInvalidBatchSignature        = errors.Register(ModuleName, 6, "batch signature is invalid")
 	ErrUnexpectedBatchSignature     = errors.Register(ModuleName, 7, "batch signature should be empty")
+	ErrNoInjectedExtendedVotesTx    = errors.Register(ModuleName, 8, "no injected extended votes tx")
 )

--- a/app/abci/handlers.go
+++ b/app/abci/handlers.go
@@ -249,6 +249,11 @@ func (h *Handlers) ProcessProposalHandler() sdk.ProcessProposalHandler {
 			return nil, err
 		}
 
+		if len(req.Txs) == 0 {
+			h.logger.Error("proposal does not contain extended votes injection")
+			return nil, ErrNoInjectedExtendedVotesTx
+		}
+
 		var extendedVotes abcitypes.ExtendedCommitInfo
 		if err := json.Unmarshal(req.Txs[0], &extendedVotes); err != nil {
 			h.logger.Error("failed to decode injected extended votes tx", "err", err)
@@ -312,6 +317,11 @@ func (h *Handlers) PreBlocker() sdk.PreBlocker {
 		batchNum := batch.BatchNumber
 
 		h.logger.Debug("begin pre-block logic for storing batch signatures", "batch_number", batchNum)
+
+		if len(req.Txs) == 0 {
+			h.logger.Error("proposal does not contain extended votes injection")
+			return nil, ErrNoInjectedExtendedVotesTx
+		}
 
 		var extendedVotes abcitypes.ExtendedCommitInfo
 		if err := json.Unmarshal(req.Txs[0], &extendedVotes); err != nil {

--- a/x/pubkey/keeper/endblock.go
+++ b/x/pubkey/keeper/endblock.go
@@ -141,12 +141,14 @@ func (k Keeper) JailValidators(ctx sdk.Context, keyIndex utils.SEDAKeyIndex) err
 			if err != nil {
 				return err
 			}
-			err = k.slashingKeeper.Jail(ctx, consAddr)
-			if err != nil {
-				return err
+			if !val.IsJailed() {
+				err = k.slashingKeeper.Jail(ctx, consAddr)
+				if err != nil {
+					return err
+				}
 			}
 			k.Logger(ctx).Info(
-				"jailed validator for missing required public key",
+				"validator is jailed for missing required public key (or was already jailed)",
 				"consensus_address", consAddr,
 				"operator_address", val.OperatorAddress,
 				"key_index", keyIndex,


### PR DESCRIPTION
This PR addresses several issues identified during the audit:
- Consume remaining tally gas in an out of gas case.
- Check that the number of transactions in a proposal is not zero to avoid panics in `ProcessProposal` and in `PreBlocker`.
- When we jail validators without the required keys during proving scheme activation, ensure that they have not already been jailed to avoid an error.