### PR TITLE
fix(abci): handle invalid vote extensions in late votes

### DIFF
--- a/app/abci/helpers_test.go
+++ b/app/abci/helpers_test.go
@@ -1,0 +1,384 @@
+package abci_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/crypto/sha3"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	cmtsecp256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
+	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	"cosmossdk.io/collections"
+	"cosmossdk.io/core/comet"
+	"cosmossdk.io/core/header"
+	"cosmossdk.io/log"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/mempool"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	protoio "github.com/cosmos/gogoproto/io"
+	"github.com/cosmos/gogoproto/proto"
+
+	"github.com/sedaprotocol/seda-chain/app/abci"
+	"github.com/sedaprotocol/seda-chain/app/abci/testutil"
+	"github.com/sedaprotocol/seda-chain/app/params"
+	"github.com/sedaprotocol/seda-chain/app/utils"
+	batchingtypes "github.com/sedaprotocol/seda-chain/x/batching/types"
+	pubkeytypes "github.com/sedaprotocol/seda-chain/x/pubkey/types"
+)
+
+var (
+	chainID = "seda-abci-test"
+)
+
+type testValidator struct {
+	consAddr    sdk.ConsAddress
+	valAddr     sdk.ValAddress
+	tmPk        cmtprotocrypto.PublicKey
+	privKey     cmtsecp256k1.PrivKey
+	isNew       bool
+	signer      utils.SEDASigner
+	handlers    *abci.Handlers
+	ethAddr     []byte
+	sedaPubKeys []pubkeytypes.IndexedPubKey
+	voteExt     []byte
+}
+
+func newTestValidator() testValidator {
+	privkey := cmtsecp256k1.GenPrivKey()
+	pubkey := privkey.PubKey()
+	tmPk := cmtprotocrypto.PublicKey{
+		Sum: &cmtprotocrypto.PublicKey_Secp256K1{
+			Secp256K1: pubkey.Bytes(),
+		},
+	}
+	return testValidator{
+		consAddr: sdk.ConsAddress(pubkey.Address()),
+		valAddr:  sdk.ValAddress(simtestutil.CreateRandomAccounts(1)[0]),
+		tmPk:     tmPk,
+		privKey:  privkey,
+	}
+}
+
+func (t testValidator) toValidator(power int64) abcitypes.Validator {
+	return abcitypes.Validator{
+		Address: t.consAddr.Bytes(),
+		Power:   power,
+	}
+}
+
+type ABCITestSuite struct {
+	suite.Suite
+
+	vals [3]testValidator
+	ctx  sdk.Context
+
+	mockBatch          batchingtypes.Batch
+	mockBatchingKeeper *testutil.MockBatchingKeeper
+	mockPubKeyKeeper   *testutil.MockPubKeyKeeper
+	mockStakingKeeper  *testutil.MockStakingKeeper
+	mockTxVerifier     *testutil.MockTxVerifier
+}
+
+func (s *ABCITestSuite) SetupSuite() {
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(params.Bech32PrefixAccAddr, params.Bech32PrefixAccPub)
+	cfg.SetBech32PrefixForValidator(params.Bech32PrefixValAddr, params.Bech32PrefixValPub)
+	cfg.SetBech32PrefixForConsensusNode(params.Bech32PrefixConsAddr, params.Bech32PrefixConsPub)
+	cfg.Seal()
+}
+
+func (s *ABCITestSuite) SetupTest(mockBatchNumber uint64, isNewValidator []bool) {
+	// Create validators and set up SEDA signer for each of them.
+	vals := [3]testValidator{
+		newTestValidator(),
+		newTestValidator(),
+		newTestValidator(),
+	}
+
+	tmpDir := s.T().TempDir()
+	for i, val := range vals {
+		dirPath := filepath.Join(tmpDir, fmt.Sprintf("%d", i))
+		err := os.MkdirAll(dirPath, 0755)
+		s.Require().NoError(err)
+
+		vals[i].sedaPubKeys, err = utils.GenerateSEDAKeys(val.valAddr, dirPath, "", false)
+		s.Require().NoError(err)
+
+		secp256k1PubKey := vals[i].sedaPubKeys[utils.SEDAKeyIndexSecp256k1].PubKey
+		vals[i].ethAddr, err = utils.PubKeyToEthAddress(secp256k1PubKey)
+		s.Require().NoError(err)
+
+		vals[i].signer, err = utils.LoadSEDASigner(filepath.Join(dirPath, utils.SEDAKeyFileName), true)
+		s.Require().NoError(err)
+
+		if isNewValidator != nil && isNewValidator[i] {
+			vals[i].isNew = true
+		}
+	}
+
+	hasher := sha3.NewLegacyKeccak256()
+	hasher.Write([]byte("Message for ECDSA signing"))
+	batchID := hasher.Sum(nil)
+	mockBatch := batchingtypes.Batch{
+		BatchNumber: mockBatchNumber,
+		BatchId:     batchID,
+		BlockHeight: 100,
+	}
+
+	s.mockBatch = mockBatch
+	s.vals = vals
+	s.ctx = sdk.Context{}.
+		WithChainID(chainID).
+		WithBlockHeight(mockBatch.BlockHeight).
+		WithConsensusParams(cmtproto.ConsensusParams{
+			Abci: &cmtproto.ABCIParams{
+				VoteExtensionsEnableHeight: 100,
+			},
+		}).
+		WithBlockHeader(cmtproto.Header{
+			ChainID: chainID,
+			Height:  mockBatch.BlockHeight,
+		}).
+		WithHeaderInfo(header.Info{
+			ChainID: chainID,
+			Height:  mockBatch.BlockHeight,
+		})
+
+	// Mock configurations (Batch 100 is created at height H)
+	ctrl := gomock.NewController(s.T())
+	mockBatchingKeeper := testutil.NewMockBatchingKeeper(ctrl)
+	mockPubKeyKeeper := testutil.NewMockPubKeyKeeper(ctrl)
+	mockStakingKeeper := testutil.NewMockStakingKeeper(ctrl)
+
+	mockBatchingKeeper.EXPECT().GetBatchForHeight(gomock.Any(), mockBatch.BlockHeight).Return(mockBatch, nil).AnyTimes()
+	mockBatchingKeeper.EXPECT().GetBatchForHeight(gomock.Any(), mockBatch.BlockHeight+1).Return(batchingtypes.Batch{}, collections.ErrNotFound).AnyTimes()
+	for i, val := range s.vals {
+		if isNewValidator != nil && isNewValidator[i] {
+			mockBatchingKeeper.EXPECT().GetValidatorTreeEntry(gomock.Any(), mockBatch.BatchNumber-1, val.valAddr).
+				Return(batchingtypes.ValidatorTreeEntry{}, collections.ErrNotFound).
+				AnyTimes()
+		} else {
+			mockBatchingKeeper.EXPECT().GetValidatorTreeEntry(gomock.Any(), mockBatch.BatchNumber-1, val.valAddr).
+				Return(batchingtypes.ValidatorTreeEntry{EthAddress: val.ethAddr}, nil).
+				AnyTimes()
+		}
+		mockPubKeyKeeper.EXPECT().GetValidatorKeys(gomock.Any(), val.valAddr.String()).
+			Return(pubkeytypes.ValidatorPubKeys{}, nil).
+			AnyTimes()
+		mockPubKeyKeeper.EXPECT().GetValidatorKeyAtIndex(gomock.Any(), val.valAddr.Bytes(), utils.SEDAKeyIndexSecp256k1).Return(val.sedaPubKeys[0].PubKey, nil).AnyTimes()
+
+		mockStakingKeeper.EXPECT().GetValidatorByConsAddr(gomock.Any(), val.consAddr).
+			Return(stakingtypes.Validator{OperatorAddress: val.valAddr.String()}, nil).
+			AnyTimes()
+	}
+	s.mockBatchingKeeper = mockBatchingKeeper
+	s.mockPubKeyKeeper = mockPubKeyKeeper
+	s.mockStakingKeeper = mockStakingKeeper
+	s.mockTxVerifier = testutil.NewMockTxVerifier(ctrl)
+
+	s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(testutil.ValidTx).Return(testutil.NewMockTx(100), nil).AnyTimes()
+	s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(testutil.InvalidTx).Return(nil, fmt.Errorf("invalid TX")).AnyTimes()
+	s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(testutil.LargeTx).Return(testutil.NewMockTx(10000), nil).AnyTimes()
+
+	// Construct handler for each validator.
+	buf := &bytes.Buffer{}
+	logger := log.NewLogger(buf, log.LevelOption(zerolog.DebugLevel))
+	for i, val := range s.vals {
+		defaultProposalHandler := baseapp.NewDefaultProposalHandler(mempool.NewSenderNonceMempool(), s.mockTxVerifier)
+		s.vals[i].handlers = abci.NewHandlers(
+			defaultProposalHandler.PrepareProposalHandler(),
+			defaultProposalHandler.ProcessProposalHandler(),
+			mockBatchingKeeper,
+			mockPubKeyKeeper,
+			mockStakingKeeper,
+			authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
+			val.signer,
+			logger,
+		)
+	}
+}
+
+func (s *ABCITestSuite) incrementBlockHeight() {
+	s.ctx = sdk.Context{}.
+		WithChainID(s.ctx.ChainID()).
+		WithBlockHeight(s.ctx.BlockHeight() + 1).
+		WithConsensusParams(cmtproto.ConsensusParams{
+			Abci: &cmtproto.ABCIParams{
+				VoteExtensionsEnableHeight: s.ctx.ConsensusParams().Abci.VoteExtensionsEnableHeight,
+			},
+			Block: &cmtproto.BlockParams{
+				MaxGas: 20000,
+			},
+		}).
+		WithBlockHeader(cmtproto.Header{
+			ChainID: s.ctx.ChainID(),
+			Height:  s.ctx.BlockHeight() + 1,
+		}).
+		WithHeaderInfo(header.Info{
+			ChainID: s.ctx.ChainID(),
+			Height:  s.ctx.BlockHeight() + 1,
+		})
+}
+
+func (s *ABCITestSuite) validatorVotes(val *testValidator) {
+	evRes, err := val.handlers.ExtendVoteHandler()(
+		s.ctx, &abcitypes.RequestExtendVote{
+			Height: s.ctx.BlockHeight(),
+		})
+	if val.isNew {
+		// New validator does not sign the batch.
+		s.Require().Error(err)
+		s.Require().Nil(evRes)
+	} else {
+		s.Require().NoError(err)
+		val.voteExt = evRes.VoteExtension
+	}
+}
+
+func (s *ABCITestSuite) validatorsVote() {
+	for i := range s.vals {
+		s.validatorVotes(&s.vals[i])
+	}
+}
+
+func (s *ABCITestSuite) injectCommitInfo(prepareRes *abcitypes.ResponsePrepareProposal, llc abcitypes.ExtendedCommitInfo) {
+	injection, err := json.Marshal(llc)
+	s.Require().NoError(err)
+	prepareRes.Txs = append(prepareRes.Txs, injection)
+}
+
+func (s *ABCITestSuite) validatorsProcessProposal(txs [][]byte, expErr string, shouldRejectProposal bool) {
+	for _, val := range s.vals {
+		processRes, err := val.handlers.ProcessProposalHandler()(
+			s.ctx, &abcitypes.RequestProcessProposal{
+				ProposedLastCommit: abcitypes.CommitInfo{
+					Round: 1,
+					Votes: nil,
+				},
+				Txs:    txs,
+				Height: s.ctx.BlockHeight(),
+			})
+		if expErr != "" {
+			s.Require().Error(err)
+			s.Require().Contains(err.Error(), expErr)
+		}
+
+		if shouldRejectProposal {
+			s.Require().Equal(abcitypes.ResponseProcessProposal_REJECT, processRes.Status, "Proposal was accepted when it should be rejected")
+			return
+		} else {
+			s.Require().Equal(abcitypes.ResponseProcessProposal_ACCEPT, processRes.Status, "Proposal was rejected when it should be accepted")
+		}
+	}
+}
+
+func (s *ABCITestSuite) mockExtendedCommitInfo() (abcitypes.ExtendedCommitInfo, comet.BlockInfo) {
+	var llc abcitypes.ExtendedCommitInfo
+	for i, val := range s.vals {
+		s.mockStakingKeeper.EXPECT().GetPubKeyByConsAddr(gomock.Any(), val.consAddr.Bytes()).Return(val.tmPk, nil).AnyTimes()
+		s.mockStakingKeeper.EXPECT().GetPubKeyByConsAddr(gomock.Any(), val.consAddr.Bytes()).Return(val.tmPk, nil).AnyTimes()
+		s.mockStakingKeeper.EXPECT().GetPubKeyByConsAddr(gomock.Any(), val.consAddr.Bytes()).Return(val.tmPk, nil).AnyTimes()
+
+		cve := cmtproto.CanonicalVoteExtension{
+			Extension: val.voteExt,
+			Height:    101,
+			Round:     int64(0),
+			ChainId:   chainID,
+		}
+
+		bz, err := marshalDelimitedFn(&cve)
+		s.Require().NoError(err)
+
+		extSig, err := val.privKey.Sign(bz)
+		s.Require().NoError(err)
+
+		blockIdFlag := cmtproto.BlockIDFlagCommit
+		if !val.isNew && len(val.voteExt) == 0 {
+			blockIdFlag = cmtproto.BlockIDFlagAbsent
+		}
+
+		llc.Votes = append(llc.Votes, abcitypes.ExtendedVoteInfo{
+			// Each validator has a slightly different power to avoid ties.
+			Validator:          val.toValidator(333 + int64(i)),
+			VoteExtension:      val.voteExt,
+			ExtensionSignature: extSig,
+			BlockIdFlag:        blockIdFlag,
+		})
+	}
+
+	// Sort and convert to last commit.
+	return extendedCommitToLastCommit(llc)
+}
+
+func marshalDelimitedFn(msg proto.Message) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := protoio.NewDelimitedWriter(&buf).WriteMsg(msg); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func extendedCommitToLastCommit(ec abcitypes.ExtendedCommitInfo) (abcitypes.ExtendedCommitInfo, comet.BlockInfo) {
+	sort.Sort(extendedVoteInfos(ec.Votes))
+
+	// Convert the extended commit info to last commit info.
+	lastCommit := abcitypes.CommitInfo{
+		Round: ec.Round,
+		Votes: make([]abcitypes.VoteInfo, len(ec.Votes)),
+	}
+	for i, vote := range ec.Votes {
+		lastCommit.Votes[i] = abcitypes.VoteInfo{
+			Validator: abcitypes.Validator{
+				Address: vote.Validator.Address,
+				Power:   vote.Validator.Power,
+			},
+			BlockIdFlag: vote.BlockIdFlag,
+		}
+	}
+	return ec, baseapp.NewBlockInfo(
+		nil,
+		nil,
+		nil,
+		lastCommit,
+	)
+}
+
+type extendedVoteInfos []abcitypes.ExtendedVoteInfo
+
+func (v extendedVoteInfos) Len() int {
+	return len(v)
+}
+
+func (v extendedVoteInfos) Less(i, j int) bool {
+	if v[i].Validator.Power == v[j].Validator.Power {
+		return bytes.Compare(v[i].Validator.Address, v[j].Validator.Address) == -1
+	}
+	return v[i].Validator.Power > v[j].Validator.Power
+}
+
+func (v extendedVoteInfos) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}
+
+func mustDecodeBase64(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/app/abci/utils.go
+++ b/app/abci/utils.go
@@ -1,0 +1,228 @@
+package abci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+
+	cometabci "github.com/cometbft/cometbft/abci/types"
+	cryptoenc "github.com/cometbft/cometbft/crypto/encoding"
+	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	protoio "github.com/cosmos/gogoproto/io"
+	"github.com/cosmos/gogoproto/proto"
+
+	"cosmossdk.io/core/comet"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// IsVoteExtensionsEnabled determines if vote extensions are enabled for the current block. If
+// vote extensions are enabled at height h, then a proposer will receive vote extensions
+// in height h+1. This is primarily utilized by any module that needs to make state changes
+// based on whether they were included in a proposal.
+func IsVoteExtensionsEnabled(ctx sdk.Context) bool {
+	cp := ctx.ConsensusParams()
+	if cp.Abci == nil || cp.Abci.VoteExtensionsEnableHeight == 0 {
+		return false
+	}
+
+	// Per the cosmos sdk, the first block should not utilize the latest finalize block state. This means
+	// vote extensions should NOT be making state changes.
+	//
+	// Ref: https://github.com/cosmos/cosmos-sdk/blob/2100a73dcea634ce914977dbddb4991a020ee345/baseapp/baseapp.go#L488-L495
+	if ctx.BlockHeight() <= 1 {
+		return false
+	}
+
+	return cp.Abci.VoteExtensionsEnableHeight < ctx.BlockHeight()
+}
+
+// ValidatorStore defines the interface contract require for verifying vote
+// extension signatures. Typically, this will be implemented by the x/staking
+// module, which has knowledge of the CometBFT public key.
+type ValidatorStore interface {
+	GetPubKeyByConsAddr(context.Context, sdk.ConsAddress) (cmtprotocrypto.PublicKey, error)
+}
+
+// ValidateVoteExtensions defines a helper function for verifying vote extension
+// signatures that may be passed or manually injected into a block proposal from
+// a proposer in PrepareProposal. It returns an error if any signature is invalid
+// or if unexpected vote extensions and/or signatures are found or less than 2/3
+// power is received.
+func ValidateVoteExtensions(
+	ctx sdk.Context,
+	valStore ValidatorStore,
+	extCommit cometabci.ExtendedCommitInfo,
+) error {
+	currentHeight := ctx.HeaderInfo().Height
+	chainID := ctx.HeaderInfo().ChainID
+	commitInfo := ctx.CometInfo().GetLastCommit()
+
+	// Check that both extCommit + commit are ordered in accordance with vp/address.
+	if err := ValidateExtendedCommitAgainstLastCommit(extCommit, commitInfo); err != nil {
+		return err
+	}
+
+	// Start checking vote extensions only **after** the vote extensions enable
+	// height, because when `currentHeight == VoteExtensionsEnableHeight`
+	// PrepareProposal doesn't get any vote extensions in its request.
+	extensionsEnabled := IsVoteExtensionsEnabled(ctx)
+	marshalDelimitedFn := func(msg proto.Message) ([]byte, error) {
+		var buf bytes.Buffer
+		if err := protoio.NewDelimitedWriter(&buf).WriteMsg(msg); err != nil {
+			return nil, err
+		}
+
+		return buf.Bytes(), nil
+	}
+
+	var (
+		// Total voting power of all vote extensions.
+		totalVP int64
+		// Total voting power of all validators that submitted valid vote extensions.
+		sumVP int64
+	)
+
+	for _, vote := range extCommit.Votes {
+		totalVP += vote.Validator.Power
+
+		if extensionsEnabled {
+			if vote.BlockIdFlag == cmtproto.BlockIDFlagCommit && len(vote.ExtensionSignature) == 0 {
+				return fmt.Errorf("vote extension signature is missing; validator addr %s",
+					vote.Validator.String(),
+				)
+			}
+			if vote.BlockIdFlag != cmtproto.BlockIDFlagCommit && len(vote.VoteExtension) != 0 {
+				return fmt.Errorf("non-commit vote extension present; validator addr %s",
+					vote.Validator.String(),
+				)
+			}
+			if vote.BlockIdFlag != cmtproto.BlockIDFlagCommit && len(vote.ExtensionSignature) != 0 {
+				return fmt.Errorf("non-commit vote extension signature present; validator addr %s",
+					vote.Validator.String(),
+				)
+			}
+		} else { // vote extensions disabled
+			if len(vote.VoteExtension) != 0 {
+				return fmt.Errorf("vote extension present but extensions disabled; validator addr %s",
+					vote.Validator.String(),
+				)
+			}
+			if len(vote.ExtensionSignature) != 0 {
+				return fmt.Errorf("vote extension signature present but extensions disabled; validator addr %s",
+					vote.Validator.String(),
+				)
+			}
+
+			continue
+		}
+
+		// Only check + include power if the vote is a commit vote. There must be super-majority, otherwise the
+		// previous block (the block vote is for) could not have been committed.
+		if vote.BlockIdFlag != cmtproto.BlockIDFlagCommit {
+			continue
+		}
+
+		valConsAddr := sdk.ConsAddress(vote.Validator.Address)
+
+		pubKeyProto, err := valStore.GetPubKeyByConsAddr(ctx, valConsAddr)
+		if err != nil {
+			continue
+		}
+
+		cmtPubKey, err := cryptoenc.PubKeyFromProto(pubKeyProto)
+		if err != nil {
+			return fmt.Errorf("failed to convert validator %X public key: %w", valConsAddr, err)
+		}
+
+		cve := cmtproto.CanonicalVoteExtension{
+			Extension: vote.VoteExtension,
+			Height:    currentHeight - 1, // the vote extension was signed in the previous height
+			Round:     int64(extCommit.Round),
+			ChainId:   chainID,
+		}
+
+		extSignBytes, err := marshalDelimitedFn(&cve)
+		if err != nil {
+			return fmt.Errorf("failed to encode CanonicalVoteExtension: %w", err)
+		}
+
+		if !cmtPubKey.VerifySignature(extSignBytes, vote.ExtensionSignature) {
+			return fmt.Errorf("failed to verify validator %X vote extension signature", valConsAddr)
+		}
+
+		sumVP += vote.Validator.Power
+	}
+
+	// This check is probably unnecessary, but better safe than sorry.
+	if totalVP <= 0 {
+		return fmt.Errorf("total voting power must be positive, got: %d", totalVP)
+	}
+
+	// If the sum of the voting power has not reached (2/3 + 1) we need to error.
+	if requiredVP := ((totalVP * 2) / 3) + 1; sumVP < requiredVP {
+		return fmt.Errorf(
+			"insufficient cumulative voting power received to verify vote extensions; got: %d, expected: >=%d",
+			sumVP, requiredVP,
+		)
+	}
+
+	return nil
+}
+
+// ValidateExtendedCommitAgainstLastCommit validates an ExtendedCommitInfo against a LastCommit. Specifically,
+// it checks that the ExtendedCommit + LastCommit (for the same height), are consistent with each other + that
+// they are ordered correctly (by voting power) in accordance with
+// [comet](https://github.com/cometbft/cometbft/blob/4ce0277b35f31985bbf2c25d3806a184a4510010/types/validator_set.go#L784).
+// Modified to not check for block ID flag consistency for absent votes, as those might have been pruned in prepare proposal.
+func ValidateExtendedCommitAgainstLastCommit(ec cometabci.ExtendedCommitInfo, lc comet.CommitInfo) error {
+	// check that the rounds are the same
+	if ec.Round != lc.Round() {
+		return fmt.Errorf("extended commit round %d does not match last commit round %d", ec.Round, lc.Round())
+	}
+
+	// check that the # of votes are the same
+	if len(ec.Votes) != lc.Votes().Len() {
+		return fmt.Errorf("extended commit votes length %d does not match last commit votes length %d", len(ec.Votes), lc.Votes().Len())
+	}
+
+	// check sort order of extended commit votes
+	if !slices.IsSortedFunc(ec.Votes, func(vote1, vote2 cometabci.ExtendedVoteInfo) int {
+		if vote1.Validator.Power == vote2.Validator.Power {
+			return bytes.Compare(vote1.Validator.Address, vote2.Validator.Address) // addresses sorted in ascending order (used to break vp conflicts)
+		}
+		return -int(vote1.Validator.Power - vote2.Validator.Power) // vp sorted in descending order
+	}) {
+		return fmt.Errorf("extended commit votes are not sorted by voting power")
+	}
+
+	addressCache := make(map[string]struct{}, len(ec.Votes))
+	// check that consistency between LastCommit and ExtendedCommit
+	for i, vote := range ec.Votes {
+		// cache addresses to check for duplicates
+		if _, ok := addressCache[string(vote.Validator.Address)]; ok {
+			return fmt.Errorf("extended commit vote address %X is duplicated", vote.Validator.Address)
+		}
+		addressCache[string(vote.Validator.Address)] = struct{}{}
+
+		lcVote := lc.Votes().Get(i)
+		if !bytes.Equal(vote.Validator.Address, lcVote.Validator().Address()) {
+			return fmt.Errorf("extended commit vote address %X does not match last commit vote address %X", vote.Validator.Address, lcVote.Validator().Address())
+		}
+		if vote.Validator.Power != lcVote.Validator().Power() {
+			return fmt.Errorf("extended commit vote power %d does not match last commit vote power %d", vote.Validator.Power, lcVote.Validator().Power())
+		}
+
+		// only check non-absent votes (these could have been modified via pruning in prepare proposal)
+		if !(vote.BlockIdFlag == cmtproto.BlockIDFlagAbsent && len(vote.VoteExtension) == 0 && len(vote.ExtensionSignature) == 0) {
+			if int32(vote.BlockIdFlag) != int32(lcVote.GetBlockIDFlag()) {
+				return fmt.Errorf("mismatched block ID flag between extended commit vote %d and last proposed commit %d", int32(vote.BlockIdFlag), int32(lcVote.GetBlockIDFlag()))
+			}
+		}
+	}
+
+	return nil
+}

--- a/app/abci/vote_extension_test.go
+++ b/app/abci/vote_extension_test.go
@@ -1,243 +1,157 @@
-package abci
+package abci_test
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
-	"golang.org/x/crypto/sha3"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
-	cmtsecp256k1 "github.com/cometbft/cometbft/crypto/secp256k1"
-	cmtprotocrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 
 	"cosmossdk.io/collections"
-	"cosmossdk.io/core/comet"
-	"cosmossdk.io/core/header"
-	"cosmossdk.io/log"
 
-	"github.com/cosmos/cosmos-sdk/baseapp"
-	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/mempool"
-	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	protoio "github.com/cosmos/gogoproto/io"
-	"github.com/cosmos/gogoproto/proto"
-
+	"github.com/sedaprotocol/seda-chain/app/abci"
 	"github.com/sedaprotocol/seda-chain/app/abci/testutil"
-	"github.com/sedaprotocol/seda-chain/app/params"
-	"github.com/sedaprotocol/seda-chain/app/utils"
-	batchingtypes "github.com/sedaprotocol/seda-chain/x/batching/types"
-	pubkeytypes "github.com/sedaprotocol/seda-chain/x/pubkey/types"
 )
-
-var (
-	chainID = "seda-abci-test"
-)
-
-type testValidator struct {
-	consAddr    sdk.ConsAddress
-	valAddr     sdk.ValAddress
-	tmPk        cmtprotocrypto.PublicKey
-	privKey     cmtsecp256k1.PrivKey
-	signer      utils.SEDASigner
-	handlers    *Handlers
-	ethAddr     []byte
-	sedaPubKeys []pubkeytypes.IndexedPubKey
-	voteExt     []byte
-}
-
-func newTestValidator() testValidator {
-	privkey := cmtsecp256k1.GenPrivKey()
-	pubkey := privkey.PubKey()
-	tmPk := cmtprotocrypto.PublicKey{
-		Sum: &cmtprotocrypto.PublicKey_Secp256K1{
-			Secp256K1: pubkey.Bytes(),
-		},
-	}
-	return testValidator{
-		consAddr: sdk.ConsAddress(pubkey.Address()),
-		valAddr:  sdk.ValAddress(simtestutil.CreateRandomAccounts(1)[0]),
-		tmPk:     tmPk,
-		privKey:  privkey,
-	}
-}
-
-func (t testValidator) toValidator(power int64) abcitypes.Validator {
-	return abcitypes.Validator{
-		Address: t.consAddr.Bytes(),
-		Power:   power,
-	}
-}
-
-type ABCITestSuite struct {
-	suite.Suite
-
-	vals [3]testValidator
-	ctx  sdk.Context
-
-	mockBatch          batchingtypes.Batch
-	mockBatchingKeeper *testutil.MockBatchingKeeper
-	mockPubKeyKeeper   *testutil.MockPubKeyKeeper
-	mockStakingKeeper  *testutil.MockStakingKeeper
-	mockTxVerifier     *testutil.MockTxVerifier
-}
-
-func (s *ABCITestSuite) SetupSuite() {
-	cfg := sdk.GetConfig()
-	cfg.SetBech32PrefixForAccount(params.Bech32PrefixAccAddr, params.Bech32PrefixAccPub)
-	cfg.SetBech32PrefixForValidator(params.Bech32PrefixValAddr, params.Bech32PrefixValPub)
-	cfg.SetBech32PrefixForConsensusNode(params.Bech32PrefixConsAddr, params.Bech32PrefixConsPub)
-	cfg.Seal()
-}
-
-func (s *ABCITestSuite) SetupTest(mockBatchNumber uint64, isNewValidator []bool) {
-	// Create validators and set up SEDA signer for each of them.
-	vals := [3]testValidator{
-		newTestValidator(),
-		newTestValidator(),
-		newTestValidator(),
-	}
-
-	tmpDir := s.T().TempDir()
-	for i, val := range vals {
-		dirPath := filepath.Join(tmpDir, fmt.Sprintf("%d", i))
-		err := os.MkdirAll(dirPath, 0755)
-		s.Require().NoError(err)
-
-		vals[i].sedaPubKeys, err = utils.GenerateSEDAKeys(val.valAddr, dirPath, "", false)
-		s.Require().NoError(err)
-
-		secp256k1PubKey := vals[i].sedaPubKeys[utils.SEDAKeyIndexSecp256k1].PubKey
-		vals[i].ethAddr, err = utils.PubKeyToEthAddress(secp256k1PubKey)
-		s.Require().NoError(err)
-
-		vals[i].signer, err = utils.LoadSEDASigner(filepath.Join(dirPath, utils.SEDAKeyFileName), true)
-		s.Require().NoError(err)
-	}
-
-	hasher := sha3.NewLegacyKeccak256()
-	hasher.Write([]byte("Message for ECDSA signing"))
-	batchID := hasher.Sum(nil)
-	mockBatch := batchingtypes.Batch{
-		BatchNumber: mockBatchNumber,
-		BatchId:     batchID,
-		BlockHeight: 100,
-	}
-
-	s.mockBatch = mockBatch
-	s.vals = vals
-	s.ctx = sdk.Context{}.
-		WithChainID(chainID).
-		WithBlockHeight(mockBatch.BlockHeight).
-		WithConsensusParams(cmtproto.ConsensusParams{
-			Abci: &cmtproto.ABCIParams{
-				VoteExtensionsEnableHeight: 100,
-			},
-		}).
-		WithBlockHeader(cmtproto.Header{
-			ChainID: chainID,
-			Height:  mockBatch.BlockHeight,
-		}).
-		WithHeaderInfo(header.Info{
-			ChainID: chainID,
-			Height:  mockBatch.BlockHeight,
-		})
-
-	// Mock configurations (Batch 100 is created at height H)
-	ctrl := gomock.NewController(s.T())
-	mockBatchingKeeper := testutil.NewMockBatchingKeeper(ctrl)
-	mockPubKeyKeeper := testutil.NewMockPubKeyKeeper(ctrl)
-	mockStakingKeeper := testutil.NewMockStakingKeeper(ctrl)
-
-	mockBatchingKeeper.EXPECT().GetBatchForHeight(gomock.Any(), mockBatch.BlockHeight).Return(mockBatch, nil).AnyTimes()
-	mockBatchingKeeper.EXPECT().GetBatchForHeight(gomock.Any(), mockBatch.BlockHeight+1).Return(batchingtypes.Batch{}, collections.ErrNotFound).AnyTimes()
-	for i, val := range s.vals {
-		if isNewValidator != nil && isNewValidator[i] {
-			mockBatchingKeeper.EXPECT().GetValidatorTreeEntry(gomock.Any(), mockBatch.BatchNumber-1, val.valAddr).
-				Return(batchingtypes.ValidatorTreeEntry{}, collections.ErrNotFound).
-				AnyTimes()
-		} else {
-			mockBatchingKeeper.EXPECT().GetValidatorTreeEntry(gomock.Any(), mockBatch.BatchNumber-1, val.valAddr).
-				Return(batchingtypes.ValidatorTreeEntry{EthAddress: val.ethAddr}, nil).
-				AnyTimes()
-		}
-		mockPubKeyKeeper.EXPECT().GetValidatorKeys(gomock.Any(), val.valAddr.String()).
-			Return(pubkeytypes.ValidatorPubKeys{}, nil).
-			AnyTimes()
-		mockPubKeyKeeper.EXPECT().GetValidatorKeyAtIndex(gomock.Any(), val.valAddr.Bytes(), utils.SEDAKeyIndexSecp256k1).Return(val.sedaPubKeys[0].PubKey, nil).AnyTimes()
-
-		mockStakingKeeper.EXPECT().GetValidatorByConsAddr(gomock.Any(), val.consAddr).
-			Return(stakingtypes.Validator{OperatorAddress: val.valAddr.String()}, nil).
-			AnyTimes()
-	}
-	s.mockBatchingKeeper = mockBatchingKeeper
-	s.mockPubKeyKeeper = mockPubKeyKeeper
-	s.mockStakingKeeper = mockStakingKeeper
-	s.mockTxVerifier = testutil.NewMockTxVerifier(ctrl)
-
-	s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(testutil.ValidTx).Return(testutil.NewMockTx(100), nil).AnyTimes()
-	s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(testutil.InvalidTx).Return(nil, fmt.Errorf("invalid TX")).AnyTimes()
-	s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(testutil.LargeTx).Return(testutil.NewMockTx(10000), nil).AnyTimes()
-
-	// Construct handler for each validator.
-	buf := &bytes.Buffer{}
-	logger := log.NewLogger(buf, log.LevelOption(zerolog.DebugLevel))
-	for i, val := range s.vals {
-		defaultProposalHandler := baseapp.NewDefaultProposalHandler(mempool.NewSenderNonceMempool(), s.mockTxVerifier)
-		s.vals[i].handlers = NewHandlers(
-			defaultProposalHandler.PrepareProposalHandler(),
-			defaultProposalHandler.ProcessProposalHandler(),
-			mockBatchingKeeper,
-			mockPubKeyKeeper,
-			mockStakingKeeper,
-			authcodec.NewBech32Codec(sdk.GetConfig().GetBech32ValidatorAddrPrefix()),
-			val.signer,
-			logger,
-		)
-	}
-}
 
 func TestABCITestSuite(t *testing.T) {
 	suite.Run(t, new(ABCITestSuite))
 }
 
-type voteExtensionOverwrite struct {
-	overwrite []bool
-	extension [][]byte
-}
-
-type maliciousProposer struct {
-	inject         []bool
-	injection      [][]byte
-	additionalVote *abcitypes.ExtendedVoteInfo
-	replaceVote    *abcitypes.ExtendedVoteInfo
-	noInjection    bool
-}
-
-func (s *ABCITestSuite) TestABCIHandlers() {
+func (s *ABCITestSuite) TestABCIHandlersVerifyVoteExtensionHandler() {
 	testCases := []struct {
-		name                 string
-		mockBatchNumber      uint64
-		heightWithoutBatch   bool
-		isNewValidator       []bool
-		overwriteVoteExt     *voteExtensionOverwrite
-		maliciousProposer    *maliciousProposer
-		additionalTxBytes    [][]byte
-		shouldRejectProposal bool
-		expErr               string
+		name               string
+		mockBatchNumber    uint64
+		isNewValidator     []bool
+		heightWithoutBatch bool
+		reqVoteExt         *abcitypes.RequestVerifyVoteExtension
+		expectedErr        string
+		shouldReject       bool
 	}{
+		{
+			name:            "new batch + valid signature",
+			mockBatchNumber: 100,
+		},
+		{
+			name:               "no batch to sign",
+			heightWithoutBatch: true,
+		},
+		{
+			name:            "new validator",
+			mockBatchNumber: 100,
+			isNewValidator:  []bool{false, true, false},
+		},
+		{
+			name:            "new batch + short signature",
+			mockBatchNumber: 100,
+			reqVoteExt:      &abcitypes.RequestVerifyVoteExtension{VoteExtension: []byte("invalid")},
+			expectedErr:     "vote extension is too short",
+			shouldReject:    true,
+		},
+		{
+			name:            "new batch + long signature",
+			mockBatchNumber: 100,
+			reqVoteExt:      &abcitypes.RequestVerifyVoteExtension{VoteExtension: make([]byte, abci.MaxVoteExtensionLength+1)},
+			expectedErr:     "vote extension exceeds max length",
+			shouldReject:    true,
+		},
+		{
+			name:            "new batch + invalid signature",
+			mockBatchNumber: 100,
+			reqVoteExt:      &abcitypes.RequestVerifyVoteExtension{VoteExtension: make([]byte, abci.MaxVoteExtensionLength)},
+			expectedErr:     "recovery failed",
+			shouldReject:    true,
+		},
+		{
+			name:               "no batch + signature",
+			heightWithoutBatch: true,
+			reqVoteExt:         &abcitypes.RequestVerifyVoteExtension{VoteExtension: []byte("garbage")},
+			shouldReject:       true,
+		},
+	}
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			s.SetupTest(tc.mockBatchNumber, tc.isNewValidator)
+
+			s.incrementBlockHeight()
+			if tc.heightWithoutBatch {
+				s.incrementBlockHeight()
+			}
+
+			// Validator 0 extends the vote.
+			if tc.reqVoteExt == nil {
+				s.validatorVotes(&s.vals[0])
+			} else {
+				s.vals[0].voteExt = tc.reqVoteExt.VoteExtension
+			}
+
+			// Validator 1 verifies the vote.
+			vvRes, err := s.vals[1].handlers.VerifyVoteExtensionHandler()(
+				s.ctx, &abcitypes.RequestVerifyVoteExtension{
+					Height:           s.ctx.BlockHeight(),
+					VoteExtension:    s.vals[0].voteExt,
+					ValidatorAddress: s.vals[0].consAddr,
+				})
+			if tc.shouldReject {
+				s.Require().Equal(abcitypes.ResponseVerifyVoteExtension_REJECT, vvRes.Status)
+				if tc.expectedErr != "" {
+					s.Require().Error(err)
+					s.Require().Contains(err.Error(), tc.expectedErr)
+				}
+			} else {
+				s.Require().NoError(err)
+				s.Require().Equal(abcitypes.ResponseVerifyVoteExtension_ACCEPT, vvRes.Status)
+			}
+		})
+	}
+}
+
+type honestTestCase struct {
+	name               string
+	mockBatchNumber    uint64
+	heightWithoutBatch bool
+	isNewValidator     []bool
+	// If set, the vote extension is not verified simulating a vote received after the block was delivered to the
+	// application and bypassing the VerifyVoteExtensionHandler.
+	voteExts           []*abcitypes.ResponseExtendVote
+	additionalTxBytes  [][]byte
+	expectedPrepareErr string
+}
+
+func (tc *honestTestCase) IsNewValidator(i int) bool {
+	if tc.isNewValidator == nil {
+		return false
+	}
+
+	return tc.isNewValidator[i]
+}
+
+func (tc *honestTestCase) IsUnverifiedVoteExtension(i int) bool {
+	if tc.voteExts == nil {
+		return false
+	}
+
+	return tc.voteExts[i] != nil
+}
+
+func (tc *honestTestCase) GetVoteExtOverwrite(i int) *abcitypes.ResponseExtendVote {
+	if tc.voteExts == nil {
+		return nil
+	}
+
+	return tc.voteExts[i]
+}
+
+func (s *ABCITestSuite) TestABCIHandlersHonestProposer() {
+	testCases := []honestTestCase{
+		{
+			name:            "first batch",
+			mockBatchNumber: collections.DefaultSequenceStart,
+		},
 		{
 			name:            "happy path without transactions",
 			mockBatchNumber: 100,
@@ -257,122 +171,36 @@ func (s *ABCITestSuite) TestABCIHandlers() {
 			heightWithoutBatch: true,
 		},
 		{
-			name:            "happy path with new validator",
+			name:            "new validators",
 			mockBatchNumber: 100,
 			isNewValidator:  []bool{false, false, true},
 		},
 		{
-			name:            "one empty vote extension",
+			name:            "new validators",
 			mockBatchNumber: 100,
-			overwriteVoteExt: &voteExtensionOverwrite{
-				overwrite: []bool{false, false, true},
-				extension: [][]byte{nil, nil, nil},
-			},
+			isNewValidator:  []bool{true, false, true},
 		},
 		{
-			name:            "first batch",
-			mockBatchNumber: collections.DefaultSequenceStart,
+			name:            "one absent vote of less than 1/3",
+			mockBatchNumber: 100,
+			voteExts:        []*abcitypes.ResponseExtendVote{{VoteExtension: []byte{}}, nil, nil},
 		},
 		{
-			name:            "unrecoverable signature is injected in proposal",
-			mockBatchNumber: 100,
-			overwriteVoteExt: &voteExtensionOverwrite{
-				overwrite: []bool{true, false, false},
-				extension: [][]byte{bytes.Repeat([]byte("b"), 65), nil, nil},
-			},
-			expErr: "invalid signature recovery id",
+			name:               "absent votes of more than 1/3",
+			mockBatchNumber:    100,
+			voteExts:           []*abcitypes.ResponseExtendVote{nil, nil, {VoteExtension: []byte{}}},
+			expectedPrepareErr: "insufficient cumulative voting power received to verify vote extensions;",
 		},
 		{
-			name:            "invalid signature is injected in proposal",
+			name:            "unverified vote extensions of less than 1/3",
 			mockBatchNumber: 100,
-			overwriteVoteExt: &voteExtensionOverwrite{
-				overwrite: []bool{false, false, true},
-				extension: [][]byte{nil, nil, {189, 92, 197, 8, 100, 52, 95, 183, 251, 111, 24, 99, 59, 203, 64, 250, 13, 35, 168, 193, 106, 244, 191, 48, 10, 108, 68, 197, 222, 59, 230, 110, 21, 108, 12, 217, 108, 92, 115, 214, 255, 70, 107, 170, 228, 54, 53, 157, 41, 140, 40, 132, 157, 197, 248, 219, 113, 227, 148, 194, 197, 46, 153, 49, 0}},
-			},
-			expErr: "batch signature is invalid",
+			voteExts:        []*abcitypes.ResponseExtendVote{{VoteExtension: []byte("this is not a valid vote extension")}, nil, nil},
 		},
 		{
-			name:            "proposer injects an empty vote extension",
-			mockBatchNumber: 100,
-			maliciousProposer: &maliciousProposer{
-				inject:    []bool{false, true, false},
-				injection: [][]byte{nil, nil, nil},
-			},
-			expErr: "", // set during test execution
-		},
-		{
-			name:            "proposer injects an arbitrary vote extension",
-			mockBatchNumber: 100,
-			maliciousProposer: &maliciousProposer{
-				inject:    []bool{false, false, true},
-				injection: [][]byte{nil, nil, {189, 92, 197, 8, 100, 52, 95, 183, 251, 111, 24, 99, 59, 203, 64, 250, 13, 35, 168, 193, 106, 244, 191, 48, 10, 108, 68, 197, 222, 59, 230, 110, 21, 108, 12, 217, 108, 92, 115, 214, 255, 70, 107, 170, 228, 54, 53, 157, 41, 140, 40, 132, 157, 197, 248, 219, 113, 227, 148, 194, 197, 46, 153, 49, 0}},
-			},
-			expErr: "", // set during test execution
-		},
-		{
-			name:            "proposer injects an additional vote",
-			mockBatchNumber: 100,
-			maliciousProposer: &maliciousProposer{
-				inject:    []bool{false, false, false},
-				injection: [][]byte{nil, nil, nil},
-				additionalVote: &abcitypes.ExtendedVoteInfo{
-					Validator: abcitypes.Validator{
-						Address: mustDecodeBase64("a5XdK0N65IhetG24u0rbKjHMcEo="),
-						Power:   333,
-					},
-					VoteExtension:      mustDecodeBase64("DSyP4ZXSX9T2s0YBAQl2GPcUpZ4pKdeFObjklK5mnSkxHxvQW51whL8ubsckGbWHNZpLP1b102VG6YZfrO/mcwE="),
-					ExtensionSignature: mustDecodeBase64("l42SpFcnbqi8EAdWeaN5KSLvF2zfTW2MXjwxoB6WweoIG3a2HHC9PP5kq3Ox1M452HBHZS2j6oDeG+OqwYmxsA=="),
-					BlockIdFlag:        cmtproto.BlockIDFlagCommit,
-				},
-			},
-			expErr: "extended commit votes length 4 does not match last commit votes length 3",
-		},
-		{
-			name:            "proposer replaces a vote",
-			mockBatchNumber: 100,
-			maliciousProposer: &maliciousProposer{
-				inject:    []bool{false, false, false},
-				injection: [][]byte{nil, nil, nil},
-				replaceVote: &abcitypes.ExtendedVoteInfo{
-					Validator: abcitypes.Validator{
-						Address: mustDecodeBase64("a5XdK0N65IhetG24u0rbKjHMcEo="),
-						Power:   400,
-					},
-					VoteExtension:      mustDecodeBase64("DSyP4ZXSX9T2s0YBAQl2GPcUpZ4pKdeFObjklK5mnSkxHxvQW51whL8ubsckGbWHNZpLP1b102VG6YZfrO/mcwE="),
-					ExtensionSignature: mustDecodeBase64("l42SpFcnbqi8EAdWeaN5KSLvF2zfTW2MXjwxoB6WweoIG3a2HHC9PP5kq3Ox1M452HBHZS2j6oDeG+OqwYmxsA=="),
-					BlockIdFlag:        cmtproto.BlockIDFlagCommit,
-				},
-			},
-			expErr: "extended commit vote address 6B95DD2B437AE4885EB46DB8BB4ADB2A31CC704A does not match last commit vote address",
-		},
-		{
-			name:            "proposer bloats the proposal with invalid txs",
-			mockBatchNumber: 100,
-			additionalTxBytes: [][]byte{
-				testutil.ValidTx,
-				testutil.ValidTx,
-				testutil.InvalidTx,
-			},
-			shouldRejectProposal: true,
-		},
-		{
-			name:            "proposer exceeds the block gas limit",
-			mockBatchNumber: 100,
-			additionalTxBytes: [][]byte{
-				testutil.LargeTx,
-				testutil.LargeTx,
-				testutil.LargeTx,
-			},
-			shouldRejectProposal: true,
-		},
-		{
-			name:            "proposer does not inject extended votes",
-			mockBatchNumber: 100,
-			maliciousProposer: &maliciousProposer{
-				noInjection: true,
-			},
-			shouldRejectProposal: true,
-			expErr:               "no injected extended votes tx",
+			name:               "unverified vote extensions of more than 1/3",
+			mockBatchNumber:    100,
+			voteExts:           []*abcitypes.ResponseExtendVote{nil, nil, {VoteExtension: []byte("this is not a valid vote extension")}},
+			expectedPrepareErr: "insufficient cumulative voting power received to verify vote extensions;",
 		},
 	}
 	for _, tc := range testCases {
@@ -383,47 +211,28 @@ func (s *ABCITestSuite) TestABCIHandlers() {
 			if tc.heightWithoutBatch {
 				s.incrementBlockHeight()
 			}
-			for i, val := range s.vals {
-				// ExtendVote at H+1
-				evRes, err := val.handlers.ExtendVoteHandler()(
-					s.ctx, &abcitypes.RequestExtendVote{
-						Height: s.ctx.BlockHeight(),
-					})
-				if tc.isNewValidator != nil && tc.isNewValidator[i] {
-					// New validator does not sign the batch.
-					s.Require().Error(err)
-					s.Require().Nil(evRes)
-				} else {
-					s.Require().NoError(err)
 
-					// Recover and verify public key.
-					if !tc.heightWithoutBatch {
-						sigPubKey, err := crypto.Ecrecover(s.mockBatch.BatchId, evRes.VoteExtension)
-						s.Require().NoError(err)
-						s.Require().Equal(val.sedaPubKeys[utils.SEDAKeyIndexSecp256k1].PubKey, sigPubKey)
-
-						s.vals[i].voteExt = evRes.VoteExtension
-						if tc.overwriteVoteExt != nil && tc.overwriteVoteExt.overwrite[i] {
-							s.vals[i].voteExt = tc.overwriteVoteExt.extension[i]
-						}
-					}
-				}
-
-				// VerifyVoteExtension at H+1 (all other validators)
-				for _, otherVal := range s.vals {
-					if otherVal.consAddr.Equals(val.consAddr) {
-						continue
-					}
-					vvRes, err := otherVal.handlers.VerifyVoteExtensionHandler()(
-						s.ctx, &abcitypes.RequestVerifyVoteExtension{
-							Height:           s.ctx.BlockHeight(),
-							VoteExtension:    s.vals[i].voteExt,
-							ValidatorAddress: val.consAddr,
-						})
-					if tc.overwriteVoteExt != nil && tc.overwriteVoteExt.overwrite[i] {
-						s.Require().Error(err)
-						s.Require().Contains(err.Error(), tc.expErr)
+			if !tc.heightWithoutBatch {
+				for i, val := range s.vals {
+					// ExtendVote at H+1
+					evRes := tc.GetVoteExtOverwrite(i)
+					if evRes == nil {
+						s.validatorVotes(&s.vals[i])
 					} else {
+						s.vals[i].voteExt = evRes.VoteExtension
+					}
+
+					// VerifyVoteExtension at H+1
+					for _, otherVal := range s.vals {
+						if otherVal.consAddr.Equals(val.consAddr) || tc.IsUnverifiedVoteExtension(i) {
+							continue
+						}
+						vvRes, err := otherVal.handlers.VerifyVoteExtensionHandler()(
+							s.ctx, &abcitypes.RequestVerifyVoteExtension{
+								Height:           s.ctx.BlockHeight(),
+								VoteExtension:    s.vals[i].voteExt,
+								ValidatorAddress: val.consAddr,
+							})
 						s.Require().NoError(err)
 						s.Require().Equal(abcitypes.ResponseVerifyVoteExtension_ACCEPT, vvRes.Status)
 					}
@@ -442,6 +251,11 @@ func (s *ABCITestSuite) TestABCIHandlers() {
 					MaxTxBytes:      22020096,
 					Height:          s.ctx.BlockHeight(),
 				})
+			if tc.expectedPrepareErr != "" {
+				s.Require().Error(err)
+				s.Require().Contains(err.Error(), tc.expectedPrepareErr)
+				return
+			}
 			s.Require().NoError(err)
 
 			// Ensure last commit was injected.
@@ -454,65 +268,19 @@ func (s *ABCITestSuite) TestABCIHandlers() {
 				s.Require().Equal(0, len(prepareRes.Txs))
 			}
 
-			if tc.maliciousProposer != nil && tc.maliciousProposer.noInjection {
-				prepareRes.Txs = nil
-			} else if tc.maliciousProposer != nil {
-				var extendedVotes abcitypes.ExtendedCommitInfo
-				err = json.Unmarshal(prepareRes.Txs[0], &extendedVotes)
-				s.Require().NoError(err)
-
-				for i := range extendedVotes.Votes {
-					if tc.maliciousProposer.inject[i] {
-						extendedVotes.Votes[i].VoteExtension = tc.maliciousProposer.injection[i]
-						if tc.expErr == "" {
-							tc.expErr = fmt.Sprintf("failed to verify validator %X vote extension signature", extendedVotes.Votes[i].Validator.Address)
-						}
-					}
-				}
-				if tc.maliciousProposer.additionalVote != nil {
-					extendedVotes.Votes = append(extendedVotes.Votes, *tc.maliciousProposer.additionalVote)
-				}
-				if tc.maliciousProposer.replaceVote != nil {
-					extendedVotes.Votes[0] = *tc.maliciousProposer.replaceVote
-				}
-
-				prepareRes.Txs[0], err = json.Marshal(extendedVotes)
-				s.Require().NoError(err)
-			}
-
 			if tc.additionalTxBytes != nil {
 				prepareRes.Txs = append(prepareRes.Txs, tc.additionalTxBytes...)
 			}
 
 			// ProcessProposal at H+2 (all validators)
-			for _, val := range s.vals {
-				processRes, err := val.handlers.ProcessProposalHandler()(
-					s.ctx, &abcitypes.RequestProcessProposal{
-						ProposedLastCommit: abcitypes.CommitInfo{
-							Round: 1,
-							Votes: nil,
-						},
-						Txs:    prepareRes.Txs,
-						Height: s.ctx.BlockHeight(),
-					})
-
-				if tc.overwriteVoteExt != nil || tc.maliciousProposer != nil {
-					s.Require().Error(err)
-					s.Require().Contains(err.Error(), tc.expErr)
-					return
-				} else {
-					s.Require().NoError(err)
-					if tc.shouldRejectProposal {
-						s.Require().Equal(abcitypes.ResponseProcessProposal_REJECT, processRes.Status, "Proposal was accepted when it should be rejected")
-					} else {
-						s.Require().Equal(abcitypes.ResponseProcessProposal_ACCEPT, processRes.Status, "Proposal was rejected when it should be accepted")
-					}
-				}
-			}
+			s.validatorsProcessProposal(prepareRes.Txs, "", false)
 
 			// PreBlocker at H+2 (all validators)
 			if !tc.heightWithoutBatch {
-				for _, val := range s.vals {
+				for i, val := range s.vals {
+					if tc.IsUnverifiedVoteExtension(i) || tc.IsNewValidator(i) {
+						continue
+					}
 					s.mockBatchingKeeper.EXPECT().SetBatchSigSecp256k1(gomock.Any(), s.mockBatch.BatchNumber, val.valAddr, val.voteExt).Return(nil).Times(len(s.vals))
 				}
 			}
@@ -528,114 +296,232 @@ func (s *ABCITestSuite) TestABCIHandlers() {
 	}
 }
 
-func (s *ABCITestSuite) incrementBlockHeight() {
-	s.ctx = sdk.Context{}.
-		WithChainID(s.ctx.ChainID()).
-		WithBlockHeight(s.ctx.BlockHeight() + 1).
-		WithConsensusParams(cmtproto.ConsensusParams{
-			Abci: &cmtproto.ABCIParams{
-				VoteExtensionsEnableHeight: s.ctx.ConsensusParams().Abci.VoteExtensionsEnableHeight,
-			},
-			Block: &cmtproto.BlockParams{
-				MaxGas: 20000,
-			},
-		}).
-		WithBlockHeader(cmtproto.Header{
-			ChainID: s.ctx.ChainID(),
-			Height:  s.ctx.BlockHeight() + 1,
-		}).
-		WithHeaderInfo(header.Info{
-			ChainID: s.ctx.ChainID(),
-			Height:  s.ctx.BlockHeight() + 1,
-		})
+func (s *ABCITestSuite) maliciousSetup() {
+	s.SetupTest(100, []bool{false, false, false})
+
+	// ExtendVote at H+1
+	s.incrementBlockHeight()
+	s.validatorsVote()
+
+	// PrepareProposal at H+2
+	s.incrementBlockHeight()
 }
 
-func (s *ABCITestSuite) mockExtendedCommitInfo() (abcitypes.ExtendedCommitInfo, comet.BlockInfo) {
-	var llc abcitypes.ExtendedCommitInfo
-	for _, val := range s.vals {
-		s.mockStakingKeeper.EXPECT().GetPubKeyByConsAddr(gomock.Any(), val.consAddr.Bytes()).Return(val.tmPk, nil).AnyTimes()
-		s.mockStakingKeeper.EXPECT().GetPubKeyByConsAddr(gomock.Any(), val.consAddr.Bytes()).Return(val.tmPk, nil).AnyTimes()
-		s.mockStakingKeeper.EXPECT().GetPubKeyByConsAddr(gomock.Any(), val.consAddr.Bytes()).Return(val.tmPk, nil).AnyTimes()
+func (s *ABCITestSuite) TestABCIHandlersMaliciousProposer() {
+	// Unfortunately there is no way to prevent pruning valid votes.
+	s.Run("proposer prunes 1/3rd of the votes despite being valid", func() {
+		s.maliciousSetup()
 
-		cve := cmtproto.CanonicalVoteExtension{
-			Extension: val.voteExt,
-			Height:    101,
-			Round:     int64(0),
-			ChainId:   chainID,
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes[2].BlockIdFlag = cmtproto.BlockIDFlagAbsent
+		llc.Votes[2].VoteExtension = nil
+		llc.Votes[2].ExtensionSignature = nil
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "", false)
+
+		// PreBlocker at H+2 (all validators)
+		for _, val := range s.vals {
+			if bytes.Equal(val.consAddr.Bytes(), llc.Votes[2].Validator.Address) {
+				continue
+			}
+			s.mockBatchingKeeper.EXPECT().SetBatchSigSecp256k1(gomock.Any(), s.mockBatch.BatchNumber, val.valAddr, val.voteExt).Return(nil).Times(len(s.vals))
 		}
+		for _, val := range s.vals {
+			_, err := val.handlers.PreBlocker()(
+				s.ctx, &abcitypes.RequestFinalizeBlock{
+					Txs:    prepareRes.Txs,
+					Height: s.ctx.BlockHeight(),
+				})
+			s.Require().NoError(err)
+		}
+	})
 
-		bz, err := marshalDelimitedFn(&cve)
-		s.Require().NoError(err)
+	s.Run("proposer prunes more than 1/3rd of the votes", func() {
+		s.maliciousSetup()
 
-		extSig, err := val.privKey.Sign(bz)
-		s.Require().NoError(err)
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes[0].BlockIdFlag = cmtproto.BlockIDFlagAbsent
+		llc.Votes[0].VoteExtension = nil
+		llc.Votes[0].ExtensionSignature = nil
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "insufficient cumulative voting power received to verify vote extensions; got: 667, expected: >=66", true)
+	})
+
+	s.Run("proposer marks a vote as absent", func() {
+		s.maliciousSetup()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes[0].BlockIdFlag = cmtproto.BlockIDFlagAbsent
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "mismatched block ID flag between extended commit vote 1 and last proposed commit", true)
+	})
+
+	s.Run("proposer injects an invalid vote extension which should have been pruned", func() {
+		s.maliciousSetup()
+
+		// Make the vote extension invalid, the call to mockExtendedCommitInfo will sign it.
+		s.vals[0].voteExt = bytes.Repeat([]byte{0x01}, 65)
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "batch signature is invalid", true)
+	})
+
+	s.Run("proposer empties a vote extension", func() {
+		s.maliciousSetup()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes[0].VoteExtension = []byte{}
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, fmt.Sprintf("failed to verify validator %X vote extension signature", llc.Votes[0].Validator.Address), true)
+	})
+
+	s.Run("proposer manipulates a vote", func() {
+		s.maliciousSetup()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes[0].VoteExtension = []byte("invalid")
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, fmt.Sprintf("failed to verify validator %X vote extension signature", llc.Votes[0].Validator.Address), true)
+	})
+
+	s.Run("proposer injects votes without batch", func() {
+		s.maliciousSetup()
+
+		s.incrementBlockHeight()
+		// The default process proposal handler should reject the proposal as it's an invalid tx.
+		s.mockTxVerifier.EXPECT().ProcessProposalVerifyTx(gomock.Any()).Return(nil, fmt.Errorf("invalid TX")).AnyTimes()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "", true)
+	})
+
+	s.Run("proposer adds an additional vote", func() {
+		s.maliciousSetup()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
 
 		llc.Votes = append(llc.Votes, abcitypes.ExtendedVoteInfo{
-			Validator:          val.toValidator(333),
-			VoteExtension:      val.voteExt,
-			ExtensionSignature: extSig,
+			Validator: abcitypes.Validator{
+				Address: mustDecodeBase64("a5XdK0N65IhetG24u0rbKjHMcEo="),
+				Power:   400,
+			},
+			VoteExtension:      mustDecodeBase64("DSyP4ZXSX9T2s0YBAQl2GPcUpZ4pKdeFObjklK5mnSkxHxvQW51whL8ubsckGbWHNZpLP1b102VG6YZfrO/mcwE="),
+			ExtensionSignature: mustDecodeBase64("l42SpFcnbqi8EAdWeaN5KSLvF2zfTW2MXjwxoB6WweoIG3a2HHC9PP5kq3Ox1M452HBHZS2j6oDeG+OqwYmxsA=="),
 			BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 		})
-	}
 
-	// Sort and convert to last commit.
-	return extendedCommitToLastCommit(llc)
-}
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
 
-func marshalDelimitedFn(msg proto.Message) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := protoio.NewDelimitedWriter(&buf).WriteMsg(msg); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
+		s.validatorsProcessProposal(prepareRes.Txs, "extended commit votes length 4 does not match last commit votes length 3", true)
+	})
 
-func extendedCommitToLastCommit(ec abcitypes.ExtendedCommitInfo) (abcitypes.ExtendedCommitInfo, comet.BlockInfo) {
-	sort.Sort(extendedVoteInfos(ec.Votes))
+	s.Run("proposer removes a vote", func() {
+		s.maliciousSetup()
 
-	// Convert the extended commit info to last commit info.
-	lastCommit := abcitypes.CommitInfo{
-		Round: ec.Round,
-		Votes: make([]abcitypes.VoteInfo, len(ec.Votes)),
-	}
-	for i, vote := range ec.Votes {
-		lastCommit.Votes[i] = abcitypes.VoteInfo{
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes = llc.Votes[1:]
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "extended commit votes length 2 does not match last commit votes length 3", true)
+	})
+
+	s.Run("proposer replaces a vote", func() {
+		s.maliciousSetup()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		llc.Votes[0] = abcitypes.ExtendedVoteInfo{
 			Validator: abcitypes.Validator{
-				Address: vote.Validator.Address,
-				Power:   vote.Validator.Power,
+				Address: mustDecodeBase64("a5XdK0N65IhetG24u0rbKjHMcEo="),
+				Power:   400,
 			},
-			BlockIdFlag: vote.BlockIdFlag,
+			VoteExtension:      mustDecodeBase64("DSyP4ZXSX9T2s0YBAQl2GPcUpZ4pKdeFObjklK5mnSkxHxvQW51whL8ubsckGbWHNZpLP1b102VG6YZfrO/mcwE="),
+			ExtensionSignature: mustDecodeBase64("l42SpFcnbqi8EAdWeaN5KSLvF2zfTW2MXjwxoB6WweoIG3a2HHC9PP5kq3Ox1M452HBHZS2j6oDeG+OqwYmxsA=="),
+			BlockIdFlag:        cmtproto.BlockIDFlagCommit,
 		}
-	}
-	return ec, baseapp.NewBlockInfo(
-		nil,
-		nil,
-		nil,
-		lastCommit,
-	)
-}
 
-type extendedVoteInfos []abcitypes.ExtendedVoteInfo
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
 
-func (v extendedVoteInfos) Len() int {
-	return len(v)
-}
+		s.validatorsProcessProposal(prepareRes.Txs, "extended commit vote address 6B95DD2B437AE4885EB46DB8BB4ADB2A31CC704A does not match last commit vote address", true)
+	})
 
-func (v extendedVoteInfos) Less(i, j int) bool {
-	if v[i].Validator.Power == v[j].Validator.Power {
-		return bytes.Compare(v[i].Validator.Address, v[j].Validator.Address) == -1
-	}
-	return v[i].Validator.Power > v[j].Validator.Power
-}
+	s.Run("proposer bloats the proposal with invalid txs", func() {
+		s.maliciousSetup()
 
-func (v extendedVoteInfos) Swap(i, j int) {
-	v[i], v[j] = v[j], v[i]
-}
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
 
-func mustDecodeBase64(s string) []byte {
-	b, err := base64.StdEncoding.DecodeString(s)
-	if err != nil {
-		panic(err)
-	}
-	return b
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+		prepareRes.Txs = append(prepareRes.Txs, testutil.ValidTx, testutil.ValidTx, testutil.InvalidTx)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "", true)
+	})
+
+	s.Run("proposer exceeds the block gas limit", func() {
+		s.maliciousSetup()
+
+		llc, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+		s.injectCommitInfo(&prepareRes, llc)
+		prepareRes.Txs = append(prepareRes.Txs, testutil.LargeTx, testutil.LargeTx, testutil.LargeTx)
+
+		s.validatorsProcessProposal(prepareRes.Txs, "", true)
+	})
+
+	s.Run("proposer does not inject extended votes", func() {
+		s.maliciousSetup()
+
+		_, info := s.mockExtendedCommitInfo()
+		s.ctx = s.ctx.WithCometInfo(info)
+
+		prepareRes := abcitypes.ResponsePrepareProposal{}
+
+		s.validatorsProcessProposal(prepareRes.Txs, "no injected extended votes tx", true)
+	})
 }


### PR DESCRIPTION
## Motivation

Since votes that arrive before the commit timeout but after the block has been delivered to the application are not verified with the verifyVoteExtension handler we need to account for potentially invalid votes in the prepareProposalHandler. Since we at least are guaranteed to receive verified votes for over 2/3rds of voting power we can simply ignore any vote that was invalid.

## Explanation of Changes

Most of the VoteExtension code is taken directly from skip-mev/connect https://github.com/skip-mev/connect/blob/main/abci/ve/vote_extension.go, which in turn is taken almost directly from the SDK https://github.com/cosmos/cosmos-sdk/blob/v0.50.13/baseapp/abci_utils.go.

## Testing

Refactored the tests significantly to make every individual test a little more clear, since the malicious proposer scenario adds so many variations that it became unwieldy with the testcases approach.

I think it can be cleaner though, so comments very much welcome. :) 

## Related PRs and Issues

N.A.
