### PR TITLE
Require batch signatures to be in low-s form

### DIFF
--- a/app/abci/vote_extension_test.go
+++ b/app/abci/vote_extension_test.go
@@ -63,7 +63,7 @@ func (s *ABCITestSuite) TestABCIHandlersVerifyVoteExtensionHandler() {
 			name:            "new batch + invalid signature",
 			mockBatchNumber: 100,
 			reqVoteExt:      &abcitypes.RequestVerifyVoteExtension{VoteExtension: make([]byte, abci.MaxVoteExtensionLength)},
-			expectedErr:     "recovery failed",
+			expectedErr:     "batch signature is invalid",
 			shouldReject:    true,
 		},
 		{


### PR DESCRIPTION
## Motivation

Since the EVM contract require signatures to be in the low-s form a malicious proposer could prevent a batch from being submitted by injecting the high-s form of signatures in a proposal. Without this change these signatures would pass the `verifyBatchSignatures` check.

## Explanation of Changes

I only modified the verification since our signatures should be in the low-s form since the library we're using normalises the signature: https://github.com/bitcoin-core/secp256k1/blob/70f149b9a1bf4ed3266f97774d0ae9577534bf40/src/ecdsa_impl.h#L294.

## Testing

Tests still pass, although one with a different error.

## Related PRs and Issues

N.A.
