### PR TITLE
Limit the amount of data proxy fee updates per block

### DIFF
--- a/x/data-proxy/keeper/msg_server.go
+++ b/x/data-proxy/keeper/msg_server.go
@@ -158,7 +158,7 @@ func (m msgServer) EditDataProxy(goCtx context.Context, msg *types.MsgEditDataPr
 		updateDelay = msg.FeeUpdateDelay
 	}
 
-	updateHeight, err := m.processProxyFeeUpdate(ctx, pubKeyBytes, proxyConfig, msg.NewFee, updateDelay)
+	updateHeight, err := m.scheduleFeeUpdate(ctx, pubKeyBytes, proxyConfig, msg.NewFee, updateDelay)
 	if err != nil {
 		return nil, err
 	}

--- a/x/data-proxy/types/errors.go
+++ b/x/data-proxy/types/errors.go
@@ -3,8 +3,9 @@ package types
 import "cosmossdk.io/errors"
 
 var (
-	ErrAlreadyExists    = errors.Register(ModuleName, 2, "data proxy already exists")
-	ErrInvalidSignature = errors.Register(ModuleName, 3, "invalid signature")
-	ErrInvalidDelay     = errors.Register(ModuleName, 4, "invalid update delay")
-	ErrEmptyUpdate      = errors.Register(ModuleName, 5, "nothing to update")
+	ErrAlreadyExists     = errors.Register(ModuleName, 2, "data proxy already exists")
+	ErrInvalidSignature  = errors.Register(ModuleName, 3, "invalid signature")
+	ErrInvalidDelay      = errors.Register(ModuleName, 4, "invalid update delay")
+	ErrEmptyUpdate       = errors.Register(ModuleName, 5, "nothing to update")
+	ErrMaxUpdatesReached = errors.Register(ModuleName, 6, "max fee updates reached for block")
 )

--- a/x/data-proxy/types/params.go
+++ b/x/data-proxy/types/params.go
@@ -5,6 +5,7 @@ import (
 )
 
 const (
+	MaxUpdatesPerBlock       int    = 25
 	DefaultMinFeeUpdateDelay uint32 = 86400 // Roughly 1 week with a ~7 sec block time
 	LowestFeeUpdateDelay     uint32 = 1
 )


### PR DESCRIPTION
Targeting other PR for easier merging.

## Motivation

As discussed it should be super unlikely that any number of data proxies schedule their update for the same block, and even if a large number needs to be coordinated it shouldn't matter that they need to be spread out over a few blocks.

## Explanation of Changes

The value 25 was randomly decided so I'm open to other values. I went with this since it's low enough that iterating doesn't matter but high enough to allow for some random collisions.

## Testing

Added a unit test to verify that scheduling an update isn't possible once the max is reached, but becomes possible again once an update is rescheduled.

## Related PRs and Issues

N.A.
