### PR TITLE
Emit rotated pubkey

### DIFF
--- a/x/pubkey/types/events.go
+++ b/x/pubkey/types/events.go
@@ -1,7 +1,8 @@
 package types
 
 const (
-	EventTypeAddKey = "add_key"
+	EventTypeAddKey    = "add_key"
+	EventTypeRemoveKey = "remove_key"
 
 	AttributePublicKey     = "public_key"
 	AttributePubKeyIndex   = "public_key_index"

--- a/x/pubkey/types/tx.go
+++ b/x/pubkey/types/tx.go
@@ -7,7 +7,7 @@ import (
 
 var _ sdk.Msg = &MsgAddKey{}
 
-func (m *MsgAddKey) Validate() error {
+func (m *MsgAddKey) ValidateBasic() error {
 	if m.ValidatorAddr == "" {
 		return sdkerrors.ErrInvalidRequest.Wrap("empty validator address")
 	}


### PR DESCRIPTION
## Motivation

Make it easier to trace a chain of pubkeys when a validators rotates them.

## Explanation of Changes

N.A.

## Testing

Added a unit test to verify the correct events are emitted.

## Related PRs and Issues

N.A.
