### PR TITLE
Data proxy and executor pubkey sorting

### DIFF
--- a/x/tally/keeper/filter_and_tally_test.go
+++ b/x/tally/keeper/filter_and_tally_test.go
@@ -594,14 +594,14 @@ func TestExecutorPayout(t *testing.T) {
 			_, tallyRes := f.tallyKeeper.FilterAndTally(f.Context(), request, types.DefaultParams(), gasMeter)
 			require.NoError(t, err)
 
-			for _, exec := range gasMeter.Executors {
+			for _, exec := range gasMeter.GetSortedExecutors(request.ID, f.Context().BlockHeight()) {
 				require.Equal(t,
 					tt.expExecutorGas[exec.PublicKey].String(),
 					exec.Amount.String(),
 				)
 			}
 			require.Equal(t, tt.expReducedPayout, gasMeter.ReducedPayout)
-			for _, proxy := range gasMeter.Proxies {
+			for _, proxy := range gasMeter.GetSortedProxies(request.ID, f.Context().BlockHeight()) {
 				require.Equal(t,
 					tt.expProxyGas[proxy.PayoutAddress].String(),
 					proxy.Amount.String(),

--- a/x/tally/keeper/gas_meter.go
+++ b/x/tally/keeper/gas_meter.go
@@ -31,7 +31,7 @@ func (k Keeper) DistributionsFromGasMeter(ctx sdk.Context, reqID string, reqHeig
 	attrs = append(attrs, sdk.NewAttribute(types.AttributeTallyGas, strconv.FormatUint(gasMeter.TallyGasUsed(), 10)))
 
 	// Append distribution messages for data proxies.
-	for _, proxy := range gasMeter.Proxies {
+	for _, proxy := range gasMeter.GetSortedProxies(reqID, ctx.BlockHeight()) {
 		proxyDist := types.NewDataProxyReward(proxy.PublicKey, proxy.PayoutAddress, proxy.Amount, gasMeter.GasPrice())
 		dists = append(dists, proxyDist)
 		attrs = append(attrs, sdk.NewAttribute(types.AttributeDataProxyGas,
@@ -41,7 +41,7 @@ func (k Keeper) DistributionsFromGasMeter(ctx sdk.Context, reqID string, reqHeig
 	// Append distribution messages for executors, burning a portion of their
 	// payouts in case of a reduced payout scenario.
 	reducedPayoutBurn := math.ZeroInt()
-	for _, executor := range gasMeter.Executors {
+	for _, executor := range gasMeter.GetSortedExecutors(reqID, ctx.BlockHeight()) {
 		payoutAmt := executor.Amount
 		if gasMeter.ReducedPayout {
 			burnAmt := burnRatio.MulInt(executor.Amount).TruncateInt()

--- a/x/tally/keeper/gas_meter_test.go
+++ b/x/tally/keeper/gas_meter_test.go
@@ -85,12 +85,12 @@ func FuzzGasMetering(f *testing.F) {
 
 		// Check executor gas used.
 		sumExec := math.NewInt(0)
-		for _, exec := range gasMeter.Executors {
+		for _, exec := range gasMeter.GetSortedExecutors("dummy-request-id", fixture.Context().BlockHeight()) {
 			sumExec = sumExec.Add(exec.Amount)
 		}
 
 		// Check proxy gas used.
-		for _, proxy := range gasMeter.Proxies {
+		for _, proxy := range gasMeter.GetSortedProxies("dummy-request-id", fixture.Context().BlockHeight()) {
 			require.Equal(t,
 				expProxyGasUsed[proxy.PayoutAddress].String(),
 				proxy.Amount.String(),

--- a/x/tally/types/hash_sort.go
+++ b/x/tally/types/hash_sort.go
@@ -1,0 +1,45 @@
+package types
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"slices"
+)
+
+type HashSortable interface {
+	GetSortKey() []byte
+}
+
+func HashSort[T HashSortable](originalItems []T, entropy []byte) []T {
+	type sortItem struct {
+		sortKey  []byte
+		original T
+	}
+	totalItems := len(originalItems)
+
+	sortItems := make([]sortItem, totalItems)
+
+	hasher := sha256.New()
+	for i := range totalItems {
+		hasher.Reset()
+
+		hasher.Write(originalItems[i].GetSortKey())
+		hasher.Write(entropy)
+
+		sortItems[i] = sortItem{
+			sortKey:  hasher.Sum(nil),
+			original: originalItems[i],
+		}
+	}
+
+	slices.SortFunc(sortItems, func(a, b sortItem) int {
+		return bytes.Compare(a.sortKey, b.sortKey)
+	})
+
+	result := make([]T, totalItems)
+	for i, item := range sortItems {
+		result[i] = item.original
+	}
+
+	return result
+}

--- a/x/tally/types/hash_sort_test.go
+++ b/x/tally/types/hash_sort_test.go
@@ -1,0 +1,116 @@
+package types
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+// TestItem implements HashSortable for testing
+type TestItem struct {
+	key string
+}
+
+func (t TestItem) GetSortKey() []byte {
+	return []byte(t.key)
+}
+
+type HashSortSuite struct {
+	suite.Suite
+}
+
+func (s *HashSortSuite) generateItems(numItems int) []TestItem {
+	items := make([]TestItem, numItems)
+	for i := range numItems {
+		items[i] = TestItem{key: string(rune(i))}
+	}
+
+	return items
+}
+
+func TestHashSortSuite(t *testing.T) {
+	suite.Run(t, new(HashSortSuite))
+}
+
+func (s *HashSortSuite) TestHashSortEmptyInput() {
+	result := HashSort(s.generateItems(0), nil)
+	s.Require().Equal(0, len(result), "HashSort() should return an empty slice for empty input")
+}
+
+func (s *HashSortSuite) TestHashSortSingleItem() {
+	items := s.generateItems(1)
+	result := HashSort(items, nil)
+
+	s.Require().Equal(1, len(result), "HashSort() should return slice with length 1 for single input")
+	s.Require().Equal(items[0].key, result[0].key, "HashSort() should return same item for single input")
+}
+
+func (s *HashSortSuite) TestHashSortSmallInput() {
+	items := s.generateItems(10)
+
+	result := HashSort(items, nil)
+
+	s.Require().Equal(10, len(result), "HashSort() should return slice with length 3 for multiple inputs")
+}
+
+func (s *HashSortSuite) TestHashSortLargeInput() {
+	items := s.generateItems(1000)
+
+	result := HashSort(items, nil)
+	s.Require().Equal(1000, len(result), "HashSort() got length %v, want %v", len(result), 1000)
+
+	// Verify all items are present
+	seen := make(map[string]bool)
+	for _, item := range result {
+		seen[item.key] = true
+	}
+	s.Require().Equal(1000, len(seen), "HashSort() lost some items")
+}
+
+func (s *HashSortSuite) TestHashSortDeterminism() {
+	// Test that the same items with same keys get sorted consistently
+	items := s.generateItems(100)
+
+	result1 := HashSort(items, nil)
+	result2 := HashSort(items, nil)
+
+	for i := range len(result1) - 1 {
+		s.Require().Equal(result1[i].key, result2[i].key, "HashSort() is not deterministic")
+	}
+
+	result3 := HashSort(items, []byte("entropy"))
+	result4 := HashSort(items, []byte("entropy"))
+
+	for i := range len(result3) - 1 {
+		s.Require().Equal(result3[i].key, result4[i].key, "HashSort() with entropy is not deterministic")
+	}
+}
+
+func (s *HashSortSuite) TestHashSortEntropy() {
+	// With 10 items, probability of all 3 being different at a position is:
+	// 1 * (9/10) * (8/10) = 0.72
+	items := s.generateItems(10)
+
+	result1 := HashSort(items, nil)
+	result2 := HashSort(items, []byte("entropy"))
+
+	heightBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(heightBytes, 100)
+	result3 := HashSort(items, append([]byte("dr_id"), heightBytes...))
+
+	// Count positions where all 3 results are different
+	differentCount := 0
+	for i := range len(result1) {
+		if result1[i].key != result2[i].key &&
+			result2[i].key != result3[i].key &&
+			result1[i].key != result3[i].key {
+			differentCount++
+		}
+	}
+
+	// With 10 items, we expect about 7.2 positions to have all different items
+	// Setting threshold at 3 to account for random variation while still being statistically significant
+	s.Require().GreaterOrEqual(differentCount, 3,
+		"Expected at least 3 positions with all different items, got %d", differentCount)
+}


### PR DESCRIPTION
## Motivation

We want to prevent executors/proxies with keys that sort favourably from obtaining rewards more often in the unlikely case where there is not enough aseda in escrow to reward all the participants.

## Explanation of Changes

I opted to use the bytes of the string representation so we don't have to deal with decoding the strings as hex.

We use the data request id and the block height at which the request is tallied as entropy to add together with the public key to produce a hash which we use for sorting.

## Testing

Added unit tests for the 

## Related PRs and Issues

N.A.