### PR TITLE
Refactor reveal sorting in tally

### DIFF
--- a/x/tally/keeper/filter.go
+++ b/x/tally/keeper/filter.go
@@ -13,9 +13,13 @@ const (
 	filterTypeMAD  byte = 0x02
 )
 
+// FilterResult is the result of filtering.
 type FilterResult struct {
-	Errors       []bool   // i-th item is true if i-th reveal is non-zero exit or corrupt
-	Outliers     []bool   // i-th item is non-zero if i-th reveal is an outlier
+	// Ordered results sorted by executor with entropy
+	Executors []string // list of executor identifiers
+	Errors    []bool   // i-th item is true if i-th reveal is non-zero exit or corrupt
+	Outliers  []bool   // i-th item is non-zero if i-th reveal is an outlier
+	// Consensus results
 	Consensus    bool     // whether consensus (either in data or in error) is reached
 	ProxyPubKeys []string // data proxy public keys in consensus
 }
@@ -44,7 +48,7 @@ func invertErrors(errors []bool) []bool {
 // the given reveals to determine consensus, proxy public keys in consensus, and
 // outliers. It assumes that the reveals are sorted by their keys and that their
 // proxy public keys are sorted.
-func ExecuteFilter(reveals []types.RevealBody, filterInput string, replicationFactor uint16, params types.Params, gasMeter *types.GasMeter) (FilterResult, error) {
+func ExecuteFilter(reveals []types.Reveal, filterInput string, replicationFactor uint16, params types.Params, gasMeter *types.GasMeter) (FilterResult, error) {
 	var res FilterResult
 	res.Errors = make([]bool, len(reveals))
 	res.Outliers = make([]bool, len(reveals))

--- a/x/tally/keeper/filter_and_tally_test.go
+++ b/x/tally/keeper/filter_and_tally_test.go
@@ -729,7 +729,7 @@ func TestExecutorPayout(t *testing.T) {
 			_, tallyRes := f.tallyKeeper.FilterAndTally(f.Context(), request, types.DefaultParams(), gasMeter)
 			require.NoError(t, err)
 
-			execGasMeter := gasMeter.GetSortedExecutors(request.ID, f.Context().BlockHeight())
+			execGasMeter := gasMeter.GetExecutorGasUsed()
 			require.Equal(t, len(tt.expExecutorGas), len(execGasMeter))
 			for _, exec := range execGasMeter {
 				require.Equal(t,
@@ -739,7 +739,7 @@ func TestExecutorPayout(t *testing.T) {
 				)
 			}
 			require.Equal(t, tt.expReducedPayout, gasMeter.ReducedPayout)
-			for _, proxy := range gasMeter.GetSortedProxies(request.ID, f.Context().BlockHeight()) {
+			for _, proxy := range gasMeter.GetProxyGasUsed(request.ID, f.Context().BlockHeight()) {
 				require.Equal(t,
 					tt.expProxyGas[proxy.PayoutAddress].String(),
 					proxy.Amount.String(),

--- a/x/tally/keeper/filter_test.go
+++ b/x/tally/keeper/filter_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"encoding/base64"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"testing"
 
@@ -876,20 +877,23 @@ func TestFilter(t *testing.T) {
 			filterInput, err := hex.DecodeString(tt.tallyInputAsHex)
 			require.NoError(t, err)
 
-			// For illustration
 			for i := 0; i < len(tt.reveals); i++ {
 				tt.reveals[i].Reveal = base64.StdEncoding.EncodeToString([]byte(tt.reveals[i].Reveal))
 			}
 
-			// Since ApplyFilter assumes the pubkeys are sorted.
+			reveals := make([]types.Reveal, len(tt.reveals))
 			for i := range tt.reveals {
 				sort.Strings(tt.reveals[i].ProxyPubKeys)
+				reveals[i] = types.Reveal{
+					Executor:   fmt.Sprintf("%d", i),
+					RevealBody: tt.reveals[i],
+				}
 			}
 
 			gasMeter := types.NewGasMeter(1e13, 0, types.DefaultMaxTallyGasLimit, math.NewIntWithDecimal(1, 18), types.DefaultGasCostBase)
 
 			result, err := keeper.ExecuteFilter(
-				tt.reveals,
+				reveals,
 				base64.StdEncoding.EncodeToString(filterInput), uint16(len(tt.reveals)),
 				types.DefaultParams(),
 				gasMeter,
@@ -911,6 +915,7 @@ func TestFilter(t *testing.T) {
 }
 
 // TestFilterWildcard tests filters with JSON paths containing wildcard expressions.
+
 func TestFilterWildcard(t *testing.T) {
 	f := initFixture(t)
 
@@ -1013,20 +1018,23 @@ func TestFilterWildcard(t *testing.T) {
 			require.NoError(t, err)
 			filterInput = append(filterInput, []byte(tt.jsonPath)...)
 
-			// For illustration
 			for i := 0; i < len(tt.reveals); i++ {
 				tt.reveals[i].Reveal = base64.StdEncoding.EncodeToString([]byte(tt.reveals[i].Reveal))
 			}
 
-			// Since ApplyFilter assumes the pubkeys are sorted.
+			reveals := make([]types.Reveal, len(tt.reveals))
 			for i := range tt.reveals {
 				sort.Strings(tt.reveals[i].ProxyPubKeys)
+				reveals[i] = types.Reveal{
+					Executor:   fmt.Sprintf("%d", i),
+					RevealBody: tt.reveals[i],
+				}
 			}
 
 			gasMeter := types.NewGasMeter(1e13, 0, types.DefaultMaxTallyGasLimit, math.NewIntWithDecimal(1, 18), types.DefaultGasCostBase)
 
 			result, err := keeper.ExecuteFilter(
-				tt.reveals,
+				reveals,
 				base64.StdEncoding.EncodeToString(filterInput), uint16(len(tt.reveals)),
 				types.DefaultParams(),
 				gasMeter,

--- a/x/tally/keeper/gas_meter.go
+++ b/x/tally/keeper/gas_meter.go
@@ -31,7 +31,7 @@ func (k Keeper) DistributionsFromGasMeter(ctx sdk.Context, reqID string, reqHeig
 	attrs = append(attrs, sdk.NewAttribute(types.AttributeTallyGas, strconv.FormatUint(gasMeter.TallyGasUsed(), 10)))
 
 	// Append distribution messages for data proxies.
-	for _, proxy := range gasMeter.GetSortedProxies(reqID, ctx.BlockHeight()) {
+	for _, proxy := range gasMeter.GetProxyGasUsed(reqID, ctx.BlockHeight()) {
 		proxyDist := types.NewDataProxyReward(proxy.PublicKey, proxy.PayoutAddress, proxy.Amount, gasMeter.GasPrice())
 		dists = append(dists, proxyDist)
 		attrs = append(attrs, sdk.NewAttribute(types.AttributeDataProxyGas,
@@ -41,7 +41,7 @@ func (k Keeper) DistributionsFromGasMeter(ctx sdk.Context, reqID string, reqHeig
 	// Append distribution messages for executors, burning a portion of their
 	// payouts in case of a reduced payout scenario.
 	reducedPayoutBurn := math.ZeroInt()
-	for _, executor := range gasMeter.GetSortedExecutors(reqID, ctx.BlockHeight()) {
+	for _, executor := range gasMeter.GetExecutorGasUsed() {
 		payoutAmt := executor.Amount
 		if gasMeter.ReducedPayout {
 			burnAmt := burnRatio.MulInt(executor.Amount).TruncateInt()

--- a/x/tally/keeper/gas_meter.go
+++ b/x/tally/keeper/gas_meter.go
@@ -132,21 +132,21 @@ func MeterExecutorGasFallback(req types.Request, gasCostFallback uint64, gasMete
 // when their gas reports are uniformly at "gasReport". If a non-nil outliers
 // slice is provided, no gas consumption will be recorded for the executors
 // specified as outliers.
-func MeterExecutorGasUniform(executors []string, gasReport uint64, outliers []bool, replicationFactor uint16, gasMeter *types.GasMeter) {
+func MeterExecutorGasUniform(reveals []types.Reveal, gasReport uint64, outliers []bool, replicationFactor uint16, gasMeter *types.GasMeter) {
 	executorGasReport := gasMeter.CorrectExecGasReportWithProxyGas(gasReport)
 	gasUsed := min(executorGasReport, gasMeter.RemainingExecGas()/uint64(replicationFactor))
-	for i, executor := range executors {
+	for i, r := range reveals {
 		if outliers != nil && outliers[i] {
 			continue
 		}
-		gasMeter.ConsumeExecGasForExecutor(executor, gasUsed)
+		gasMeter.ConsumeExecGasForExecutor(r.Executor, gasUsed)
 	}
 }
 
 // MeterExecutorGasDivergent computes and records the gas consumption of executors
 // when their gas reports are divergent. If a non-nil outliers slice is provided,
 // no gas consumption will be recorded for the executors specified as outliers.
-func MeterExecutorGasDivergent(executors []string, gasReports []uint64, outliers []bool, replicationFactor uint16, gasMeter *types.GasMeter) {
+func MeterExecutorGasDivergent(reveals []types.Reveal, gasReports []uint64, outliers []bool, replicationFactor uint16, gasMeter *types.GasMeter) {
 	var lowestReport uint64
 	var lowestReporterIndex int
 	adjGasReports := make([]uint64, len(gasReports))
@@ -169,7 +169,7 @@ func MeterExecutorGasDivergent(executors []string, gasReports []uint64, outliers
 		lowestGasUsed = math.NewIntFromUint64(lowestReport * 2).Mul(totalGasUsed).Quo(totalShares).Uint64()
 		regGasUsed = math.NewIntFromUint64(medianGasUsed).Mul(totalGasUsed).Quo(totalShares).Uint64()
 	}
-	for i, executor := range executors {
+	for i, r := range reveals {
 		if outliers != nil && outliers[i] {
 			continue
 		}
@@ -177,7 +177,7 @@ func MeterExecutorGasDivergent(executors []string, gasReports []uint64, outliers
 		if i == lowestReporterIndex {
 			gasUsed = lowestGasUsed
 		}
-		gasMeter.ConsumeExecGasForExecutor(executor, gasUsed)
+		gasMeter.ConsumeExecGasForExecutor(r.Executor, gasUsed)
 	}
 }
 

--- a/x/tally/keeper/gas_meter_test.go
+++ b/x/tally/keeper/gas_meter_test.go
@@ -171,7 +171,12 @@ func ReproductionTestReducedPayoutWithProxies(t *testing.T) {
 	gasMeter := types.NewGasMeter(150000000000000, 300000000000000, types.DefaultMaxTallyGasLimit, math.NewInt(100000), types.DefaultGasCostBase)
 	fixture.tallyKeeper.MeterProxyGas(fixture.Context(), []string{"020173bd90e73c5f8576b3141c53aa9959b10a1daf1bc9c0ccf0a942932c703dec", "03b27f2df0cbdb5cdadff5b4be0c9fda5aa3a59557ef6d0b49b4298ef42c8ce2b0", "03b27f2df0cbdb5cdadff5b4be0c9fda5aa3a59557ef6d0b49b4298ef42c8ce2b0", "03b27f2df0cbdb5cdadff5b4be0c9fda5aa3a59557ef6d0b49b4298ef42c8ce2b0"}, 1, gasMeter)
 
-	keeper.MeterExecutorGasUniform([]string{"020c4fe9e5063e7b5051284423089682082cf085a3b8f9e86bdb30407d761efc49"}, 81644889168750, []bool{false}, 1, gasMeter)
+	keeper.MeterExecutorGasUniform(
+		[]types.Reveal{
+			{Executor: "020c4fe9e5063e7b5051284423089682082cf085a3b8f9e86bdb30407d761efc49"},
+		},
+		81644889168750, []bool{false}, 1, gasMeter,
+	)
 
 	require.Equalf(t, uint64(81644889168750), gasMeter.ExecutionGasUsed(), "expected exec gas used %d, got %d", 81644889168750, gasMeter.ExecutionGasUsed())
 	require.Equalf(t, uint64(1000000000000), gasMeter.TallyGasUsed(), "expected tally gas used %d, got %d", 1000000100000, gasMeter.TallyGasUsed())

--- a/x/tally/keeper/gas_meter_test.go
+++ b/x/tally/keeper/gas_meter_test.go
@@ -85,12 +85,12 @@ func FuzzGasMetering(f *testing.F) {
 
 		// Check executor gas used.
 		sumExec := math.NewInt(0)
-		for _, exec := range gasMeter.GetSortedExecutors("dummy-request-id", fixture.Context().BlockHeight()) {
+		for _, exec := range gasMeter.GetExecutorGasUsed() {
 			sumExec = sumExec.Add(exec.Amount)
 		}
 
 		// Check proxy gas used.
-		for _, proxy := range gasMeter.GetSortedProxies("dummy-request-id", fixture.Context().BlockHeight()) {
+		for _, proxy := range gasMeter.GetProxyGasUsed("dummy-request-id", fixture.Context().BlockHeight()) {
 			require.Equal(t,
 				expProxyGasUsed[proxy.PayoutAddress].String(),
 				proxy.Amount.String(),

--- a/x/tally/keeper/tally_vm.go
+++ b/x/tally/keeper/tally_vm.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/x/tally/types"
 )
 
-func (k Keeper) ExecuteTallyProgram(ctx sdk.Context, req types.Request, filterResult FilterResult, reveals []types.RevealBody, gasMeter *types.GasMeter) (types.VMResult, error) {
+func (k Keeper) ExecuteTallyProgram(ctx sdk.Context, req types.Request, filterResult FilterResult, reveals []types.Reveal, gasMeter *types.GasMeter) (types.VMResult, error) {
 	tallyProgram, err := k.wasmStorageKeeper.GetOracleProgram(ctx, req.TallyProgramID)
 	if err != nil {
 		return types.VMResult{}, k.logErrAndRet(ctx, err, types.ErrFindingTallyProgram, req)
@@ -71,7 +71,7 @@ func (k Keeper) ExecuteTallyProgram(ctx sdk.Context, req types.Request, filterRe
 	return result, nil
 }
 
-func tallyVMArg(inputArgs []byte, reveals []types.RevealBody, outliers []bool) ([]string, error) {
+func tallyVMArg(inputArgs []byte, reveals []types.Reveal, outliers []bool) ([]string, error) {
 	arg := []string{hex.EncodeToString(inputArgs)}
 
 	r, err := json.Marshal(reveals)

--- a/x/tally/keeper/tally_vm_test.go
+++ b/x/tally/keeper/tally_vm_test.go
@@ -33,21 +33,30 @@ func TestExecuteTallyProgram_RandomString(t *testing.T) {
 		PaybackAddress: base64.StdEncoding.EncodeToString([]byte("0x0")),
 	}, keeper.FilterResult{
 		Outliers: []bool{false, true, false},
-	}, []types.RevealBody{
+	}, []types.Reveal{
 		{
-			Reveal:       base64.StdEncoding.EncodeToString([]byte("{\"value\":\"one\"}")),
-			ProxyPubKeys: []string{},
-			GasUsed:      10,
+			Executor: "0",
+			RevealBody: types.RevealBody{
+				Reveal:       base64.StdEncoding.EncodeToString([]byte("{\"value\":\"one\"}")),
+				ProxyPubKeys: []string{},
+				GasUsed:      10,
+			},
 		},
 		{
-			Reveal:       base64.StdEncoding.EncodeToString([]byte("{\"value\":\"two\"}")),
-			ProxyPubKeys: []string{},
-			GasUsed:      10,
+			Executor: "1",
+			RevealBody: types.RevealBody{
+				Reveal:       base64.StdEncoding.EncodeToString([]byte("{\"value\":\"two\"}")),
+				ProxyPubKeys: []string{},
+				GasUsed:      10,
+			},
 		},
 		{
-			Reveal:       base64.StdEncoding.EncodeToString([]byte("{\"value\":\"three\"}")),
-			ProxyPubKeys: []string{},
-			GasUsed:      10,
+			Executor: "2",
+			RevealBody: types.RevealBody{
+				Reveal:       base64.StdEncoding.EncodeToString([]byte("{\"value\":\"three\"}")),
+				ProxyPubKeys: []string{},
+				GasUsed:      10,
+			},
 		},
 	}, gasMeter)
 
@@ -73,7 +82,7 @@ func TestExecuteTallyProgram_InvalidImports(t *testing.T) {
 		PaybackAddress: base64.StdEncoding.EncodeToString([]byte("0x0")),
 	}, keeper.FilterResult{
 		Outliers: []bool{},
-	}, []types.RevealBody{}, gasMeter)
+	}, []types.Reveal{}, gasMeter)
 
 	require.NoError(t, err)
 	require.NotEqual(t, uint32(0), vmRes.ExitCode)

--- a/x/tally/types/filters.go
+++ b/x/tally/types/filters.go
@@ -19,7 +19,7 @@ type Filter interface {
 	// list, whose value at index i indicates whether i-th reveal is
 	// an outlier, and a boolean indicating whether consensus in reveal
 	// data has been reached.
-	ApplyFilter(reveals []RevealBody, errors []bool) ([]bool, bool)
+	ApplyFilter(reveals []Reveal, errors []bool) ([]bool, bool)
 }
 
 type FilterNone struct{}
@@ -34,7 +34,7 @@ func NewFilterNone(gasCost uint64, gasMeter *GasMeter) (FilterNone, error) {
 }
 
 // FilterNone declares all reveals as non-outliers.
-func (f FilterNone) ApplyFilter(reveals []RevealBody, _ []bool) ([]bool, bool) {
+func (f FilterNone) ApplyFilter(reveals []Reveal, _ []bool) ([]bool, bool) {
 	return make([]bool, len(reveals)), true
 }
 
@@ -78,7 +78,7 @@ func NewFilterMode(input []byte, gasCostMultiplier uint64, replicationFactor uin
 // A reveal is declared an outlier if it does not match the mode value.
 // If less than 2/3 of the reveals are non-outliers, "no consensus"
 // error is returned along with an outlier list.
-func (f FilterMode) ApplyFilter(reveals []RevealBody, errors []bool) ([]bool, bool) {
+func (f FilterMode) ApplyFilter(reveals []Reveal, errors []bool) ([]bool, bool) {
 	dataList, dataAttrs := parseReveals(reveals, f.dataPath, errors)
 
 	outliers := make([]bool, len(reveals))
@@ -188,7 +188,7 @@ func NewFilterMAD(input []byte, gasCostMultiplier uint64, replicationFactor uint
 // outlier list. A reveal is declared an outlier if it deviates from the median
 // by more than the median absolute deviation multiplied by the given sigma
 // multiplier value.
-func (f FilterMAD) ApplyFilter(reveals []RevealBody, errors []bool) ([]bool, bool) {
+func (f FilterMAD) ApplyFilter(reveals []Reveal, errors []bool) ([]bool, bool) {
 	dataList, _ := parseReveals(reveals, f.dataPath, errors)
 	return detectOutliersBigInt(dataList, f.sigmaMultiplier, errors, f.replicationFactor, f.minNumber, f.maxNumber)
 }

--- a/x/tally/types/filters_util.go
+++ b/x/tally/types/filters_util.go
@@ -18,7 +18,7 @@ type dataAttributes struct {
 // It also updates the given errors list to indicate true for the items
 // that are corrupted. Note when an i-th reveal is corrupted, the i-th
 // item in the data list is left as an empty string.
-func parseReveals(reveals []RevealBody, dataPath string, errors []bool) ([]string, dataAttributes) {
+func parseReveals(reveals []Reveal, dataPath string, errors []bool) ([]string, dataAttributes) {
 	var parser gen.Parser
 	var maxFreq int
 	freq := make(map[string]int, len(reveals))

--- a/x/tally/types/gas_meter.go
+++ b/x/tally/types/gas_meter.go
@@ -153,22 +153,23 @@ func (g *GasMeter) ConsumeExecGasForExecutor(executorPubKey string, amount uint6
 	}
 }
 
-// GetSortedProxies returns a list of proxies sorted by hash of their public
-// keys and (drID, height) entropy.
-func (g *GasMeter) GetSortedProxies(drID string, height int64) []ProxyGasUsed {
+// GetProxyGasUsed returns a list of gas used amounts by the data proxies.
+// The list is sorted by their public keys with entropy from data request ID
+// and block height.
+func (g *GasMeter) GetProxyGasUsed(drID string, height int64) []ProxyGasUsed {
 	return HashSort(g.proxies, GetEntropy(drID, height))
 }
 
-// GetSortedExecutors returns a list of executors sorted by hash of their public
-// keys and (drID, height) entropy.
-func (g *GasMeter) GetSortedExecutors(drID string, height int64) []ExecutorGasUsed {
-	return HashSort(g.executors, GetEntropy(drID, height))
+// GetExecutorGasUsed returns a list of gas used amounts by the executors. The
+// list should already have been sorted with entropy by SanitizeReveals() except
+// in the case where the number of commits is less than the replication factor.
+func (g *GasMeter) GetExecutorGasUsed() []ExecutorGasUsed {
+	return g.executors
 }
 
 func GetEntropy(drID string, height int64) []byte {
 	heightBytes := make([]byte, 8)
 	//nolint:gosec // G115: We shouldn't get negative block heights anyway.
 	binary.BigEndian.PutUint64(heightBytes, uint64(height))
-
 	return append([]byte(drID), heightBytes...)
 }

--- a/x/tally/types/gas_meter.go
+++ b/x/tally/types/gas_meter.go
@@ -156,16 +156,16 @@ func (g *GasMeter) ConsumeExecGasForExecutor(executorPubKey string, amount uint6
 // GetSortedProxies returns a list of proxies sorted by hash of their public
 // keys and (drID, height) entropy.
 func (g *GasMeter) GetSortedProxies(drID string, height int64) []ProxyGasUsed {
-	return HashSort(g.proxies, getEntropy(drID, height))
+	return HashSort(g.proxies, GetEntropy(drID, height))
 }
 
 // GetSortedExecutors returns a list of executors sorted by hash of their public
 // keys and (drID, height) entropy.
 func (g *GasMeter) GetSortedExecutors(drID string, height int64) []ExecutorGasUsed {
-	return HashSort(g.executors, getEntropy(drID, height))
+	return HashSort(g.executors, GetEntropy(drID, height))
 }
 
-func getEntropy(drID string, height int64) []byte {
+func GetEntropy(drID string, height int64) []byte {
 	heightBytes := make([]byte, 8)
 	//nolint:gosec // G115: We shouldn't get negative block heights anyway.
 	binary.BigEndian.PutUint64(heightBytes, uint64(height))


### PR DESCRIPTION
## Explanation of Changes

PR #538 introduced sorting data proxy and executor payout lists with entropy in order to ensure some level of fairness when the contract goes through the lists in order until the fees are exhausted. This change, however, did not address the scenario where divergent gas reports involve multiple lowest reporters. To address both issues, this PR moves the executor sorting with entropy from the payout message construction phase to the beginning of tally process of a given request.
