### PR TITLE
Custom app config for SEDA key file path

### DIFF
--- a/app/abci/helpers_test.go
+++ b/app/abci/helpers_test.go
@@ -117,14 +117,15 @@ func (s *ABCITestSuite) SetupTest(mockBatchNumber uint64, isNewValidator []bool)
 		err := os.MkdirAll(dirPath, 0755)
 		s.Require().NoError(err)
 
-		vals[i].sedaPubKeys, err = utils.GenerateSEDAKeys(val.valAddr, dirPath, "", false)
+		keyfile := filepath.Join(dirPath, "seda_keys.json")
+		vals[i].sedaPubKeys, err = utils.GenerateSEDAKeys(val.valAddr, keyfile, "", false)
 		s.Require().NoError(err)
 
 		secp256k1PubKey := vals[i].sedaPubKeys[sedatypes.SEDAKeyIndexSecp256k1].PubKey
 		vals[i].ethAddr, err = utils.PubKeyToEthAddress(secp256k1PubKey)
 		s.Require().NoError(err)
 
-		vals[i].signer, err = utils.LoadSEDASigner(filepath.Join(dirPath, utils.SEDAKeyFileName), true)
+		vals[i].signer, err = utils.LoadSEDASigner(keyfile, true)
 		s.Require().NoError(err)
 
 		if isNewValidator != nil && isNewValidator[i] {

--- a/app/app.go
+++ b/app/app.go
@@ -999,10 +999,12 @@ func NewApp(
 	app.SetEndBlocker(app.EndBlocker)
 
 	// Register ABCI handlers for batch signing.
-	pvKeyFile := filepath.Join(homePath, cast.ToString(appOpts.Get("priv_validator_key_file")))
-	signer, err := utils.LoadSEDASigner(filepath.Join(filepath.Dir(pvKeyFile), utils.SEDAKeyFileName), utils.ShouldAllowUnencryptedSedaKeys(appOpts))
+	sedaConfig := utils.GetSEDAConfig(appOpts)
+	signer, err := utils.LoadSEDASigner(filepath.Join(homePath, sedaConfig.SEDAKey), utils.ShouldAllowUnencryptedSedaKeys(appOpts))
 	if err != nil {
 		app.Logger().Error("error loading SEDA signer", "err", err)
+	} else {
+		app.Logger().Info("successfully loaded SEDA signer")
 	}
 
 	// Since in prior versions -1 would be written to the config file and

--- a/app/utils/seda_config.go
+++ b/app/utils/seda_config.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"path/filepath"
+
+	"github.com/spf13/cast"
+
+	tmcfg "github.com/cometbft/cometbft/config"
+
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+)
+
+const (
+	// DefaultSEDATemplate should be added to the app.toml file for SEDA-specific
+	// configurations.
+	DefaultSEDATemplate = `
+
+###############################################################################
+###                                   SEDA                                  ###
+###############################################################################
+
+[seda]
+
+# seda_key_file is the path to the SEDA key file from the node's home directory.
+seda_key_file = "{{ .SEDAConfig.SEDAKey }}"
+`
+)
+
+var defaultSEDAKeyPath = filepath.Join(tmcfg.DefaultConfigDir, "seda_keys.json")
+
+type SEDAConfig struct {
+	SEDAKey string `mapstructure:"seda_key_file"`
+}
+
+func DefaultSEDAConfig() SEDAConfig {
+	return SEDAConfig{
+		SEDAKey: defaultSEDAKeyPath,
+	}
+}
+
+// GetSEDAConfig parses an AppOptions and returns a SEDAConfig. If the "seda"
+// key is not present in the AppOptions, it returns a default value.
+func GetSEDAConfig(appOpts servertypes.AppOptions) SEDAConfig {
+	v := appOpts.Get("seda")
+	if v == nil {
+		return DefaultSEDAConfig()
+	}
+	configMap := cast.ToStringMapString(v)
+	return SEDAConfig{
+		SEDAKey: configMap["seda_key_file"],
+	}
+}

--- a/app/utils/seda_keys_test.go
+++ b/app/utils/seda_keys_test.go
@@ -42,13 +42,12 @@ func (s *SEDAKeysTestSuite) TestSEDAKeyEncryptionDecryption() {
 	require.NoError(s.T(), err)
 
 	tempDir := s.T().TempDir()
-	generatedKeys, err := utils.GenerateSEDAKeys(valAddr, tempDir, encryptionKey, false)
+	keyfilePath := filepath.Join(tempDir, "seda_keys.json")
+	generatedKeys, err := utils.GenerateSEDAKeys(valAddr, keyfilePath, encryptionKey, false)
 
 	s.Require().NoError(err)
 	s.Require().Equal(sedatypes.SEDAKeyIndex(generatedKeys[0].Index), sedatypes.SEDAKeyIndexSecp256k1)
 	s.Require().NotEmpty(generatedKeys[0].PubKey, "public key should not be empty")
-
-	keyfilePath := filepath.Join(tempDir, utils.SEDAKeyFileName)
 
 	invalidKey, err := utils.GenerateSEDAKeyEncryptionKey()
 	s.Require().NoError(err)
@@ -63,13 +62,13 @@ func (s *SEDAKeysTestSuite) TestSEDAKeyEncryptionDecryption() {
 
 func (s *SEDAKeysTestSuite) TestSEDAKeyDecryptionExistingFile() {
 	tempDir := s.T().TempDir()
-	err := os.WriteFile(filepath.Join(tempDir, utils.SEDAKeyFileName), []byte("kNYhCAjfN9BhJ46iYzJWCUXn9efOAGf30D81UjF5tRlRtdiziW1zGVK+6ehxeJXKcPAmWjQkTxAKcJv7ozAA0xdleR4yO6HakROtFRXlOBy3K9Fv6rkDfCmbIUUjOH9oGP2F5+ldKeE5030MOdNORWUKW7fIlnKUyBWTZfLSmsKi+iCaIyZ/bFh2+NDiESPHAYl+X8t+SKKy6MgAwarrW9W1/6enNLoVmF8dAJ1dhxeKyXF/aXWKR7HaMRwe7V1NjfnaFcI09CeibpWud9rYKhbjV3K0/RdBobjPTIHAnLd5erh/3eVo9RGm8bC8a97obKm68lDernSN9HvjoTO3QlvI0k7cVDAhiuphS4qlgjOVW+eWm+S5dlD2gpCExcmrqxbggLOtjoZbQyrKhQFmfn5UGonoDTSbwtbZZtvY1N48AVT4eueReBWumcipO0ViWnkxLNIJ8vFA"), 0o600)
+	err := os.WriteFile(filepath.Join(tempDir, "seda_keys.json"), []byte("kNYhCAjfN9BhJ46iYzJWCUXn9efOAGf30D81UjF5tRlRtdiziW1zGVK+6ehxeJXKcPAmWjQkTxAKcJv7ozAA0xdleR4yO6HakROtFRXlOBy3K9Fv6rkDfCmbIUUjOH9oGP2F5+ldKeE5030MOdNORWUKW7fIlnKUyBWTZfLSmsKi+iCaIyZ/bFh2+NDiESPHAYl+X8t+SKKy6MgAwarrW9W1/6enNLoVmF8dAJ1dhxeKyXF/aXWKR7HaMRwe7V1NjfnaFcI09CeibpWud9rYKhbjV3K0/RdBobjPTIHAnLd5erh/3eVo9RGm8bC8a97obKm68lDernSN9HvjoTO3QlvI0k7cVDAhiuphS4qlgjOVW+eWm+S5dlD2gpCExcmrqxbggLOtjoZbQyrKhQFmfn5UGonoDTSbwtbZZtvY1N48AVT4eueReBWumcipO0ViWnkxLNIJ8vFA"), 0o600)
 	s.Require().NoError(err)
 
-	_, err = utils.LoadSEDAPubKeys(filepath.Join(tempDir, utils.SEDAKeyFileName), "xmp1EDn7ndgZIdgwupJ9yfDWlSssubKpgo2ZHqjx+4w=")
+	_, err = utils.LoadSEDAPubKeys(filepath.Join(tempDir, "seda_keys.json"), "xmp1EDn7ndgZIdgwupJ9yfDWlSssubKpgo2ZHqjx+4w=")
 	s.Require().ErrorContains(err, "cipher: message authentication failed")
 
-	keys, err := utils.LoadSEDAPubKeys(filepath.Join(tempDir, utils.SEDAKeyFileName), "La1PSNwUBZXEoIQ1CM0VF+kRr9vqforxE97afYdTF+c=")
+	keys, err := utils.LoadSEDAPubKeys(filepath.Join(tempDir, "seda_keys.json"), "La1PSNwUBZXEoIQ1CM0VF+kRr9vqforxE97afYdTF+c=")
 	s.Require().NoError(err)
 	s.Require().Equal(hex.EncodeToString(keys[0].PubKey), "04be41e55492d9d823c435b6b6801413223b31fdfa0318d2dea51e1886215e8664e234c34afa7af32ec02a1d0289ce656bab3ed106646836c9d26ce35968b2ff68")
 }
@@ -79,13 +78,13 @@ func (s *SEDAKeysTestSuite) TestSEDAKeyWithoutEncryption() {
 	require.NoError(s.T(), err)
 
 	tempDir := s.T().TempDir()
-	generatedKeys, err := utils.GenerateSEDAKeys(valAddr, tempDir, "", false)
+	keyfilePath := filepath.Join(tempDir, "seda_keys.json")
+	generatedKeys, err := utils.GenerateSEDAKeys(valAddr, keyfilePath, "", false)
 
 	s.Require().NoError(err)
 	s.Require().Equal(sedatypes.SEDAKeyIndex(generatedKeys[0].Index), sedatypes.SEDAKeyIndexSecp256k1)
 	s.Require().NotEmpty(generatedKeys[0].PubKey, "public key should not be empty")
 
-	keyfilePath := filepath.Join(tempDir, utils.SEDAKeyFileName)
 	keys, err := os.ReadFile(keyfilePath)
 	s.Require().NoError(err)
 

--- a/cmd/sedad/cmd/config.go
+++ b/cmd/sedad/cmd/config.go
@@ -8,36 +8,20 @@ import (
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 
 	"github.com/sedaprotocol/seda-chain/app/params"
+	"github.com/sedaprotocol/seda-chain/app/utils"
 )
 
-// initTendermintConfig helps to override default Tendermint Config values.
-// return tmcfg.DefaultConfig if no custom configuration is required for the application.
-func initTendermintConfig() *tmcfg.Config {
-	cfg := tmcfg.DefaultConfig()
-
-	// Log Settings
-	cfg.LogFormat = "json"
-	// cfg.LogLevel
-
-	// RPC Settings
-	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
-
-	// Consensus Settings
-	cfg.Consensus.TimeoutPropose = time.Duration(7.5 * float64(time.Second))
-	cfg.Consensus.TimeoutProposeDelta = time.Duration(0)
-	cfg.Consensus.TimeoutCommit = time.Duration(7.5 * float64(time.Second))
-
-	return cfg
+// AppConfig defines the application configurations. It extends the default
+// Cosmos SDK server config with custom SEDA configurations.
+type AppConfig struct {
+	serverconfig.Config
+	SEDAConfig utils.SEDAConfig `mapstructure:"seda_config"`
 }
 
 // initAppConfig helps to override default appConfig template and configs.
 // return "", nil if no custom configuration is required for the application.
 func initAppConfig() (string, interface{}) {
 	// The following code snippet is just for reference.
-
-	type CustomAppConfig struct {
-		serverconfig.Config
-	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
 	// server config.
@@ -69,10 +53,31 @@ func initAppConfig() (string, interface{}) {
 	srvCfg.API.Address = "tcp://0.0.0.0:1317"
 	srvCfg.API.EnableUnsafeCORS = true
 
-	customAppConfig := CustomAppConfig{
-		Config: *srvCfg,
+	config := AppConfig{
+		Config:     *srvCfg,
+		SEDAConfig: utils.DefaultSEDAConfig(),
 	}
-	customAppTemplate := serverconfig.DefaultConfigTemplate
+	template := serverconfig.DefaultConfigTemplate + utils.DefaultSEDATemplate
 
-	return customAppTemplate, customAppConfig
+	return template, config
+}
+
+// initTendermintConfig helps to override default Tendermint Config values.
+// return tmcfg.DefaultConfig if no custom configuration is required for the application.
+func initTendermintConfig() *tmcfg.Config {
+	cfg := tmcfg.DefaultConfig()
+
+	// Log Settings
+	cfg.LogFormat = "json"
+	// cfg.LogLevel
+
+	// RPC Settings
+	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
+
+	// Consensus Settings
+	cfg.Consensus.TimeoutPropose = time.Duration(7.5 * float64(time.Second))
+	cfg.Consensus.TimeoutProposeDelta = time.Duration(0)
+	cfg.Consensus.TimeoutCommit = time.Duration(7.5 * float64(time.Second))
+
+	return cfg
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,7 +1,7 @@
 package e2e
 
 var (
-	runWasmStorageTest = false
+	runWasmStorageTest = true
 	runBatchingTest    = true
 )
 

--- a/e2e/validator.go
+++ b/e2e/validator.go
@@ -238,7 +238,7 @@ func (v *validator) buildCreateValidatorMsg(amount sdk.Coin, valHomeDir string) 
 		return nil, err
 	}
 
-	sedaPubKeys, err := utils.GenerateSEDAKeys(sdk.ValAddress(valAddr), filepath.Join(valHomeDir, "config"), "", true)
+	sedaPubKeys, err := utils.GenerateSEDAKeys(sdk.ValAddress(valAddr), filepath.Join(valHomeDir, "config/seda_keys.json"), "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/testnet/create_genesis.sh
+++ b/scripts/testnet/create_genesis.sh
@@ -97,10 +97,10 @@ cat $HOME/.sedad/config/genesis.json | jq '.app_state["slashing"]["params"]["sla
 
 # consensus params
 cat $HOME/.sedad/config/genesis.json | jq '.consensus["params"]["block"]["max_gas"]="100000000"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
-cat $HOME/.sedad/config/genesis.json | jq '.consensus["params"]["abci"]["vote_extensions_enable_height"]="100"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
+cat $HOME/.sedad/config/genesis.json | jq '.consensus["params"]["abci"]["vote_extensions_enable_height"]="50"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
 
 # pubkey params
-cat $HOME/.sedad/config/genesis.json | jq '.app_state["pubkey"]["params"]["activation_block_delay"]="25"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
+cat $HOME/.sedad/config/genesis.json | jq '.app_state["pubkey"]["params"]["activation_block_delay"]="50"' > $HOME/.sedad/config/tmp_genesis.json && mv $HOME/.sedad/config/tmp_genesis.json $HOME/.sedad/config/genesis.json
 
 
 ###################################################
@@ -154,7 +154,7 @@ if [ ${#MONIKERS[@]} -ne 0 ]; then
         # to output geneis file
         $LOCAL_BIN add-genesis-account $VALIDATOR_ADDRESS ${GENESIS_AMOUNT}seda
 
-        $LOCAL_BIN gentx ${MONIKERS[$i]} ${SELF_DELEGATION_AMOUNTS[$i]}seda --moniker=${MONIKERS[$i]} --keyring-backend=test --home $INDIVIDUAL_VAL_HOME_DIR --ip=${IPS[$i]} --chain-id $CHAIN_ID
+        $LOCAL_BIN gentx ${MONIKERS[$i]} ${SELF_DELEGATION_AMOUNTS[$i]}seda --moniker=${MONIKERS[$i]} --key-file-custom-encryption-key=true --keyring-backend=test --home $INDIVIDUAL_VAL_HOME_DIR --ip=${IPS[$i]} --chain-id $CHAIN_ID
 
         cp -a $INDIVIDUAL_VAL_CONFIG_DIR/gentx/. $GENTX_DIR
     done

--- a/x/staking/simulation/operations.go
+++ b/x/staking/simulation/operations.go
@@ -157,7 +157,7 @@ func SimulateMsgCreateSEDAValidator(
 			simtypes.RandomDecAmount(r, maxCommission),
 		)
 
-		sedaPubKeys, err := utils.GenerateSEDAKeys(address, "", "", true)
+		sedaPubKeys, err := utils.GenerateSEDAKeys(address, "seda_keys.json", "", true)
 		if err != nil {
 			return simtypes.NoOpMsg(sdktypes.ModuleName, msgType, "unable to generate SEDA keys"), nil, err
 		}


### PR DESCRIPTION
## Explanation of Changes
We have been using the same directory as the private validator key file for storing and finding the SEDA key file since this path is provided by the CometBFT configuration. Since the SEDA key file is used by the application, this PR creates a new configuration to the `app.toml` file. The default location for the key file remains the same at `$NODE_HOME/config/seda_keys.json`.

This configuration value can be queried with the following command:

```
$ sedad config get app seda.seda_key_file             
"config/seda_keys.json"
```
