### PR TITLE
Minor refactor of SEDA Keys and config

### DIFF
--- a/cmd/sedad/cmd/config.go
+++ b/cmd/sedad/cmd/config.go
@@ -100,6 +100,11 @@ func preUpgradeCmd() *cobra.Command {
 }
 
 func migrateAppConfig(serverCtx *server.Context, rootDir string) error {
+	value := serverCtx.Viper.Get("seda")
+	if value == nil {
+		return nil // seda config already exists
+	}
+
 	configPath := filepath.Join(rootDir, "config")
 	appConfigPath := filepath.Join(configPath, "app.toml")
 

--- a/interchaintest/seda_chain.go
+++ b/interchaintest/seda_chain.go
@@ -32,10 +32,6 @@ func NewSEDAChain(cosmosChain *cosmos.CosmosChain, logger *zap.Logger) *SEDAChai
 	}
 }
 
-func (c *SEDAChain) Config() ibc.ChainConfig {
-	return c.CosmosChain.Config()
-}
-
 // Bootstraps the chain and starts it from genesis
 func (c *SEDAChain) Start(testName string, ctx context.Context, additionalGenesisWallets ...ibc.WalletAmount) error {
 	chainCfg := c.Config()

--- a/scripts/local_multi_setup.sh
+++ b/scripts/local_multi_setup.sh
@@ -42,6 +42,8 @@ $BIN keys add validator3 --keyring-backend=test --home=$HOME/.sedad/validator3
 $BIN keys add validator4 --keyring-backend=test --home=$HOME/.sedad/validator4
 
 # create validator node with tokens to transfer to the three other nodes
+sed -i '' 's/allow-unencrypted-seda-keys = false/allow-unencrypted-seda-keys = true/' $HOME/.sedad/validator1/config/app.toml
+
 $BIN add-genesis-account $($BIN keys show validator1 -a --keyring-backend=test --home=$HOME/.sedad/validator1) 100000000000000000000aseda --home=$HOME/.sedad/validator1
 $BIN gentx validator1 10000000000000000000aseda --keyring-backend=test --home=$HOME/.sedad/validator1 --key-file-no-encryption --chain-id=testing 
 $BIN collect-gentxs --home=$HOME/.sedad/validator1
@@ -54,13 +56,10 @@ $BIN collect-gentxs --home=$HOME/.sedad/validator1
 # validator4 1314, 9086
 
 # change app.toml values
-VALIDATOR1_APP_TOML=$HOME/.sedad/validator1/config/app.toml
 VALIDATOR2_APP_TOML=$HOME/.sedad/validator2/config/app.toml
 VALIDATOR3_APP_TOML=$HOME/.sedad/validator3/config/app.toml
 VALIDATOR4_APP_TOML=$HOME/.sedad/validator4/config/app.toml
 
-# validator1
-sed -i '' 's/allow-unencrypted-seda-keys = false/allow-unencrypted-seda-keys = true/' $VALIDATOR1_APP_TOML
 # validator2
 sed -i '' -E 's|tcp://0.0.0.0:1317|tcp://0.0.0.0:1316|g' $VALIDATOR2_APP_TOML # API server
 sed -i '' -E 's|0.0.0.0:9090|0.0.0.0:9088|g' $VALIDATOR2_APP_TOML # gRPC server
@@ -126,7 +125,7 @@ sed -i '' -E 's|tcp://0.0.0.0:26656|tcp://0.0.0.0:26647|g' $VALIDATOR4_CONFIG # 
 # modify genesis file
 jq '.consensus.params.block.max_gas="100000000"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
 jq '.consensus.params.abci.vote_extensions_enable_height = "10"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
-jq '.app_state["pubkey"]["params"]["activation_block_delay"]="25"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
+jq '.app_state["pubkey"]["params"]["activation_block_delay"]="15"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
 jq '.app_state["gov"]["voting_params"]["voting_period"]="30s"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
 jq '.app_state["gov"]["params"]["voting_period"]="30s"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
 jq '.app_state["gov"]["params"]["expedited_voting_period"]="15s"' $HOME/.sedad/validator1/config/genesis.json > temp.json && mv temp.json $HOME/.sedad/validator1/config/genesis.json
@@ -168,6 +167,7 @@ $BIN tx bank send validator1 $($BIN keys show validator4 -a --keyring-backend=te
 sleep 10
 
 echo "begin sending create validator txs"
+
 cat << EOF > validator2.json
 {
 	"pubkey": $($BIN tendermint show-validator --home=$HOME/.sedad/validator2),

--- a/x/pubkey/client/cli/keyfile.go
+++ b/x/pubkey/client/cli/keyfile.go
@@ -28,17 +28,12 @@ func LoadOrGenerateSEDAKeys(cmd *cobra.Command, valAddr sdk.ValAddress) ([]types
 		return nil, err
 	}
 
-	encryptionKeyEnv := utils.ReadSEDAKeyEncryptionKeyFromEnv()
 	useCustomEncryptionKey, err := cmd.Flags().GetBool(FlagEncryptionKey)
 	if err != nil {
 		return nil, err
 	}
 
-	if useCustomEncryptionKey && encryptionKeyEnv != "" {
-		return nil, fmt.Errorf("both --%s flag and %s environment variable are set", FlagEncryptionKey, utils.SEDAKeyEncryptionKeyEnvVar)
-	}
-
-	encryptionKey := encryptionKeyEnv
+	encryptionKey := ""
 	if useCustomEncryptionKey {
 		customKey, err := speakeasy.FAsk(os.Stderr, "Enter the custom encryption key\n")
 		if err != nil {


### PR DESCRIPTION
-  Do not read environment variable for encryption key when generating SEDA Keys. 
   - From my experience, using the environment variable value as an encryption key when generating SEDA Keys was prone to cause confusion. Now to use a custom encryption key, you have to pass the custom encryption flag and provide the key when prompted. 
- In pre-upgrade, return success without migrating if "seda" app config already exists.
- Fix local multi validator setup script.
