### PR TITLE
Improve SEDA signer configuration logic

### DIFF
--- a/app/abci/handlers.go
+++ b/app/abci/handlers.go
@@ -95,6 +95,7 @@ func (h *Handlers) ExtendVoteHandler() sdk.ExtendVoteHandler {
 				h.logger.Error("failed to load signer to sign batch", "err", err)
 				return nil, err
 			}
+			h.logger.Info("signer has been reloaded successfully")
 		}
 
 		// Check if the validator was in the previous validator tree. If not,
@@ -124,7 +125,7 @@ func (h *Handlers) ExtendVoteHandler() sdk.ExtendVoteHandler {
 		}
 		err = h.signer.ReloadIfMismatch(valKeys.IndexedPubKeys)
 		if err != nil {
-			return nil, err
+			h.logger.Error("failed to reload signer despite mismatch")
 		}
 
 		h.logger.Debug(

--- a/app/app.go
+++ b/app/app.go
@@ -1011,10 +1011,9 @@ func NewApp(
 		// Register ABCI handlers for batch signing.
 		signer, err = utils.LoadSEDASigner(filepath.Join(homePath, sedaConfig.SEDAKeyFile), sedaConfig.AllowUnencryptedSEDAKeys)
 		if err != nil {
-			app.Logger().Error("error loading SEDA signer", "err", err)
-		} else {
-			app.Logger().Info("successfully loaded SEDA signer")
+			panic(fmt.Errorf("error loading SEDA signer: %w", err))
 		}
+		app.Logger().Info("successfully loaded SEDA signer")
 	}
 
 	// Since in prior versions -1 would be written to the config file and

--- a/app/app.go
+++ b/app/app.go
@@ -135,7 +135,6 @@ import (
 	"github.com/sedaprotocol/seda-chain/app/keepers"
 	appparams "github.com/sedaprotocol/seda-chain/app/params"
 	"github.com/sedaprotocol/seda-chain/app/utils"
-
 	// Used in cosmos-sdk when registering the route for swagger docs.
 	_ "github.com/sedaprotocol/seda-chain/client/docs/statik"
 	"github.com/sedaprotocol/seda-chain/cmd/sedad/gentx"

--- a/cmd/sedad/cmd/config.go
+++ b/cmd/sedad/cmd/config.go
@@ -101,7 +101,7 @@ func preUpgradeCmd() *cobra.Command {
 
 func migrateAppConfig(serverCtx *server.Context, rootDir string) error {
 	value := serverCtx.Viper.Get("seda")
-	if value == nil {
+	if value != nil {
 		return nil // seda config already exists
 	}
 
@@ -116,9 +116,8 @@ func migrateAppConfig(serverCtx *server.Context, rootDir string) error {
 	}
 
 	sedaConfig := utils.DefaultSEDAConfig()
-	// Allow unencrypted key file to to prevent panic in node startup until the
-	// key file is created.
-	sedaConfig.AllowUnencryptedSEDAKeys = true
+	// SEDA signer is disabled to prevent panic in node startup after upgrade.
+	sedaConfig.EnableSEDASigner = false
 	newConfig := utils.AppConfig{
 		Config:     *oldConfig,
 		SEDAConfig: sedaConfig,

--- a/interchaintest/chain_start_test.go
+++ b/interchaintest/chain_start_test.go
@@ -21,7 +21,7 @@ func TestChainStart(t *testing.T) {
 	numOfValidators := 2
 	numOfFullNodes := 0
 
-	chains := CreateChains(t, numOfValidators, numOfFullNodes, GetSEDAAppTomlOverrides())
+	chains := CreateChains(t, numOfValidators, numOfFullNodes, GetConfigFileOverrides())
 	ic, ctx, _, _ := BuildAllChains(t, chains)
 
 	chain := chains[0].(*SEDAChain)

--- a/interchaintest/ica_test.go
+++ b/interchaintest/ica_test.go
@@ -69,8 +69,8 @@ func TestInterchainAccounts(t *testing.T) {
 	const relayerName = "relayer"
 
 	ic := interchaintest.NewInterchain().
-		AddChain(icadChain).
 		AddChain(sedaChain).
+		AddChain(icadChain).
 		AddRelayer(r, relayerName).
 		AddLink(interchaintest.InterchainLink{
 			Chain1:  icadChain,

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -139,14 +139,6 @@ func GetConfigFileOverrides() map[string]any {
 	return configFileOverrides
 }
 
-func getSEDAAppTomlOverrides() map[string]any {
-	appTomlOverrides := make(testutil.Toml)
-	appTomlOverrides["seda.enable-seda-signer"] = false
-	appTomlOverrides["seda.seda-key-file"] = "./config/seda_keys.json"
-	appTomlOverrides["seda.allow-unencrypted-seda-keys"] = true
-	return appTomlOverrides
-}
-
 // CreateChains generates this branch's chain (ex: from the commit)
 func CreateChains(t *testing.T, numVals, numFullNodes int, configFileOverrides map[string]any) []ibc.Chain {
 	t.Helper()

--- a/interchaintest/setup.go
+++ b/interchaintest/setup.go
@@ -123,20 +123,28 @@ func GetTestGenesis() []cosmos.GenesisKV {
 func GetSEDAConfig() ibc.ChainConfig {
 	cfg := SedaCfg
 	cfg.ModifyGenesis = cosmos.ModifyGenesis(GetTestGenesis())
-	cfg.ConfigFileOverrides = GetSEDAAppTomlOverrides()
+	cfg.ConfigFileOverrides = GetConfigFileOverrides()
 	return cfg
 }
 
-func GetSEDAAppTomlOverrides() map[string]any {
+func GetConfigFileOverrides() map[string]any {
 	appTomlOverrides := make(testutil.Toml)
 
-	appTomlOverrides["seda.enable-seda-signer"] = true
+	appTomlOverrides["seda.enable-seda-signer"] = false
 	appTomlOverrides["seda.seda-key-file"] = "./config/seda_keys.json"
 	appTomlOverrides["seda.allow-unencrypted-seda-keys"] = true
 
 	configFileOverrides := make(map[string]any)
 	configFileOverrides["config/app.toml"] = appTomlOverrides
 	return configFileOverrides
+}
+
+func getSEDAAppTomlOverrides() map[string]any {
+	appTomlOverrides := make(testutil.Toml)
+	appTomlOverrides["seda.enable-seda-signer"] = false
+	appTomlOverrides["seda.seda-key-file"] = "./config/seda_keys.json"
+	appTomlOverrides["seda.allow-unencrypted-seda-keys"] = true
+	return appTomlOverrides
 }
 
 // CreateChains generates this branch's chain (ex: from the commit)

--- a/interchaintest/state_sync_test.go
+++ b/interchaintest/state_sync_test.go
@@ -88,12 +88,12 @@ func modifyAppToml(snapshotInterval int) map[string]any {
 	appTomlOverrides["pruning-keep-every"] = snapshotInterval
 	appTomlOverrides["pruning-interval"] = snapshotInterval
 
-	appTomlOverrides["seda.enable-seda-signer"] = true
-	appTomlOverrides["seda.seda-key-file"] = "./config/seda_keys.json"
-	appTomlOverrides["seda.allow-unencrypted-seda-keys"] = true
+	sedaAppTomlOverrides := getSEDAAppTomlOverrides()
+	for k, v := range sedaAppTomlOverrides {
+		appTomlOverrides[k] = v
+	}
 
 	configFileOverrides := make(map[string]any)
 	configFileOverrides["config/app.toml"] = appTomlOverrides
-
 	return configFileOverrides
 }

--- a/interchaintest/state_sync_test.go
+++ b/interchaintest/state_sync_test.go
@@ -88,10 +88,9 @@ func modifyAppToml(snapshotInterval int) map[string]any {
 	appTomlOverrides["pruning-keep-every"] = snapshotInterval
 	appTomlOverrides["pruning-interval"] = snapshotInterval
 
-	sedaAppTomlOverrides := getSEDAAppTomlOverrides()
-	for k, v := range sedaAppTomlOverrides {
-		appTomlOverrides[k] = v
-	}
+	appTomlOverrides["seda.enable-seda-signer"] = false
+	appTomlOverrides["seda.seda-key-file"] = "./config/seda_keys.json"
+	appTomlOverrides["seda.allow-unencrypted-seda-keys"] = true
 
 	configFileOverrides := make(map[string]any)
 	configFileOverrides["config/app.toml"] = appTomlOverrides

--- a/scripts/local_multi_setup.sh
+++ b/scripts/local_multi_setup.sh
@@ -143,19 +143,16 @@ sed -i '' -E "s|persistent_peers = \"\"|persistent_peers = \"${NODE1_ID}@localho
 # start all four validators
 tmux new-session -s validator1 -d 
 tmux send -t validator1 'BIN=./build/sedad' ENTER
-tmux send -t validator1 '$BIN start --home=$HOME/.sedad/validator1 --log_level debug > val1_multi_local.log 2>&1 &' ENTER
+tmux send -t validator1 '$BIN start --home=$HOME/.sedad/validator1 > val1_multi_local.log 2>&1 &' ENTER
 
 tmux new-session -s validator2 -d 
 tmux send -t validator2 'BIN=./build/sedad' ENTER
-tmux send -t validator2 '$BIN start --home=$HOME/.sedad/validator2 --log_level debug > val2_multi_local.log 2>&1 &' ENTER
 
 tmux new-session -s validator3 -d 
 tmux send -t validator3 'BIN=./build/sedad' ENTER
-tmux send -t validator3 '$BIN start --home=$HOME/.sedad/validator3 --log_level debug > val3_multi_local.log 2>&1 &' ENTER
 
 tmux new-session -s validator4 -d 
 tmux send -t validator4 'BIN=./build/sedad' ENTER
-tmux send -t validator4 '$BIN start --home=$HOME/.sedad/validator4 --log_level debug > val4_multi_local.log 2>&1 &' ENTER
 
 echo "begin sending funds to validators 2, 3, & 4"
 sleep 10
@@ -185,6 +182,7 @@ cat << EOF > validator2.json
 EOF
 $BIN tx staking create-validator validator2.json --from=validator2 --keyring-backend=test --home=$HOME/.sedad/validator2 --broadcast-mode sync --chain-id=testing --node http://localhost:26657 --yes --gas-prices 10000000000aseda --gas auto --gas-adjustment 1.7 --key-file-no-encryption
 rm validator2.json
+tmux send -t validator2 '$BIN start --home=$HOME/.sedad/validator2 --log_level debug > val2_multi_local.log 2>&1 &' ENTER
 
 cat << EOF > validator3.json
 {
@@ -203,6 +201,7 @@ cat << EOF > validator3.json
 EOF
 $BIN tx staking create-validator validator3.json --from=validator3 --keyring-backend=test --home=$HOME/.sedad/validator3 --broadcast-mode sync --chain-id=testing --node http://localhost:26657 --yes --gas-prices 10000000000aseda --gas auto --gas-adjustment 1.7 --key-file-no-encryption
 rm validator3.json
+tmux send -t validator3 '$BIN start --home=$HOME/.sedad/validator3 --log_level debug > val3_multi_local.log 2>&1 &' ENTER
 
 cat << EOF > validator4.json
 {
@@ -221,6 +220,7 @@ cat << EOF > validator4.json
 EOF
 $BIN tx staking create-validator validator4.json --from=validator4 --keyring-backend=test --home=$HOME/.sedad/validator4 --broadcast-mode sync --chain-id=testing --node http://localhost:26657 --yes --gas-prices 10000000000aseda --gas auto --gas-adjustment 1.7 --key-file-no-encryption
 rm validator4.json
+tmux send -t validator4 '$BIN start --home=$HOME/.sedad/validator4 --log_level debug > val4_multi_local.log 2>&1 &' ENTER
 
 sleep 10
 echo "4 validators are up and running!"

--- a/x/pubkey/types/params.go
+++ b/x/pubkey/types/params.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	DefaultActivationBlockDelay       = 11520 // roughly 1 day
+	DefaultActivationBlockDelay       = 50
 	DefaultActivationThresholdPercent = 80
 )
 


### PR DESCRIPTION
## Explanation of Changes

- Panic at startup if signer loading fails when it is enabled in config.
- Fix pre-upgrade logic.
- ExtendVote should not fail even if signer reload due to mismatch fails.
