### PR TITLE
Revert change in default proving scheme activation delay

### DIFF
--- a/x/pubkey/types/params.go
+++ b/x/pubkey/types/params.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	DefaultActivationBlockDelay       = 50
+	DefaultActivationBlockDelay       = 11520 // roughly 1 day
 	DefaultActivationThresholdPercent = 80
 )
 


### PR DESCRIPTION
Revert the parameter value we changed for test release