### PR TITLE
Support setting SEDA key file encryption key through a file

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,57 @@
+<!--
+    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.
+
+    Please help us understand your motivation by explaining why you decided to make this change.
+
+    Happy contributing!
+-->
+
+## Motivation
+
+(Write your motivation here)
+
+## Explanation of Changes
+
+<!-- Please explain why you made these changes the way you did.  -->
+
+(Write your explanation here)
+
+## Testing
+
+<!--
+    How do you test these changes?
+	What command do you run to test these changes specifically?
+-->
+
+(Write your test plan here)
+
+## Dependency Chain
+[data-proxy]:https://github.com/sedaprotocol/seda-data-proxy
+[evm-contracts]:https://github.com/sedaprotocol/seda-evm-contracts
+[sdk]: https://github.com/sedaprotocol/seda-sdk
+[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
+[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
+[solver]:https://github.com/sedaprotocol/seda-solver
+[chain-indexer-plugin]: https://github.com/sedaprotocol/seda-chain
+[explorer/indexer]: https://github.com/sedaprotocol/seda-explorer
+
+Think about the changes (msgs, events, limits, etc.) made in this PR and see if you need to make an issue or a PR on the following repos.
+
+- [ ] [data-proxy][data-proxy]
+- [ ] [evm-contracts][evm-contracts]
+- [ ] [sdk][sdk]
+- [ ] [overlay-rs][overlay-rs]
+- [ ] [overlay-ts][overlay-ts]
+- [ ] [solver][solver]
+- [ ] [chain-indexer-plugin][chain-indexer-plugin]
+- [ ] [explorer/indexer][explorer/indexer]
+
+
+## Related PRs and Issues
+
+<!--
+    Please link to any relevant Issues and PRs.
+    Also, please link to any relevant SIPs.
+-->
+
+(Link your related PRs and Issues here)

--- a/app/utils/seda_keys.go
+++ b/app/utils/seda_keys.go
@@ -24,15 +24,31 @@ import (
 )
 
 const (
-	// SEDAKeyEncryptionKeyEnvVar is the environment variable that should contain the SEDA key encryption key.
+	// SEDAKeyEncryptionKeyEnvVar is the environment variable that contains
+	// the encryption key to the SEDA key file.
 	SEDAKeyEncryptionKeyEnvVar = "SEDA_KEYS_ENCRYPTION_KEY"
+	// SEDAKeyEncryptionKeyFile is the environment variable that contains the
+	// path to the file that contains the encryption key to the SEDA key file.
+	SEDAKeyEncryptionKeyFile = "FILE__SEDA_KEYS_ENCRYPTION_KEY"
 )
 
-// ReadSEDAKeyEncryptionKeyFromEnv reads the SEDA key encryption key from
-// the environment variable. Returns an empty string if the environment
-// variable is not set.
+// ReadSEDAKeyEncryptionKeyFromEnv attempts to read an encryption key to the
+// SEDA key file from the environment variable. It returns an empty string if
+// no encryption key is found. We also allow users to specify a file that
+// contains an encryption key through an environment variable.
 func ReadSEDAKeyEncryptionKeyFromEnv() string {
-	return os.Getenv(SEDAKeyEncryptionKeyEnvVar)
+	keyFile := os.Getenv(SEDAKeyEncryptionKeyFile)
+	if keyFile != "" && cmtos.FileExists(keyFile) {
+		keyBytes, err := os.ReadFile(keyFile)
+		if err == nil {
+			return string(keyBytes)
+		}
+	}
+	key := os.Getenv(SEDAKeyEncryptionKeyEnvVar)
+	if key != "" {
+		return key
+	}
+	return ""
 }
 
 func GenerateSEDAKeyEncryptionKey() (string, error) {


### PR DESCRIPTION
## Motivation

There were requests from validators to support configuring the encryption key for a SEDA key file through a file in addition to an environment variable. This PR adds a new environment variable `FILE_SEDA_KEYS_ENCRYPTION_KEY` whose value, if present, would indicate a path to the file that contains an encryption key to the SEDA key file.

Also adds a dependency list to the pull request template.
