### PR TITLE
Upgrade tallyvm to v2.4.0

### DIFF
--- a/cmd/sedad/gentx/gentx.go
+++ b/cmd/sedad/gentx/gentx.go
@@ -276,13 +276,7 @@ func readUnsignedGenTxFile(clientCtx client.Context, r io.Reader) (sdk.Tx, error
 	if err != nil {
 		return nil, err
 	}
-
-	aTx, err := clientCtx.TxConfig.TxJSONDecoder()(bz)
-	if err != nil {
-		return nil, err
-	}
-
-	return aTx, err
+	return clientCtx.TxConfig.TxJSONDecoder()(bz)
 }
 
 func writeSignedGenTx(clientCtx client.Context, outputDocument string, tx sdk.Tx) error {

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/zerolog v1.33.0
-	github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.3.0
+	github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.4.0
 	github.com/sedaprotocol/vrf-go v0.0.0-20231211075603-e5a17bb0b87c
 	github.com/spf13/cast v1.7.1
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -978,8 +978,8 @@ github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6v
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sedaprotocol/rosetta-seda v0.0.0-20240427181737-e1d7563b2529 h1:VbJcd022MkoohRyAfktHnN99Brt/4eJr01mdLqPhGaE=
 github.com/sedaprotocol/rosetta-seda v0.0.0-20240427181737-e1d7563b2529/go.mod h1:GdlDqGJN2g55PHiwYJs2bQMlL0rdlQQbauK4dcrOI6w=
-github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.3.0 h1:Bz6rY9Ju7u1ChTuI/1g6K3dpagFNf9TJ9mSRoGCGWMU=
-github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.3.0/go.mod h1:GnPFBlYHV+AcpLcUKcxkNkfHf2CtmTSmPbHat8flDBY=
+github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.4.0 h1:qVtX8DOeweu1axivYQ4HuT9JPLyiAsMek1BDHsN+y5g=
+github.com/sedaprotocol/seda-wasm-vm/tallyvm/v2 v2.4.0/go.mod h1:GnPFBlYHV+AcpLcUKcxkNkfHf2CtmTSmPbHat8flDBY=
 github.com/sedaprotocol/vrf-go v0.0.0-20231211075603-e5a17bb0b87c h1:PbSn7HpWeox6lqBu6Ba6YZS3On3euwn1BPz/egsnEgA=
 github.com/sedaprotocol/vrf-go v0.0.0-20231211075603-e5a17bb0b87c/go.mod h1:DEIXHk41VUzOMVbZnIApssPXtZ+2zrETDP7kJjGc1RM=
 github.com/shamaton/msgpack/v2 v2.2.0 h1:IP1m01pHwCrMa6ZccP9B3bqxEMKMSmMVAVKk54g3L/Y=

--- a/x/vesting/types/codec.go
+++ b/x/vesting/types/codec.go
@@ -12,7 +12,7 @@ import (
 )
 
 // RegisterLegacyAminoCodec registers the vesting interfaces and concrete types on the
-// provided LegacyAmino codec. These types are used for Amino JSON serialization
+// provided LegacyAmino codec. These types are used for Amino JSON serialization.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterInterface((*exported.VestingAccount)(nil), nil)
 	cdc.RegisterConcrete(&authvestingtypes.BaseVestingAccount{}, "cosmos-sdk/BaseVestingAccount", nil)
@@ -21,8 +21,8 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	legacy.RegisterAminoMsg(cdc, &MsgCreateVestingAccount{}, "cosmos-sdk/MsgCreateVestingAccount")
 }
 
-// RegisterInterface associates protoName with AccountI and VestingAccount
-// Interfaces and creates a registry of it's concrete implementations
+// RegisterInterfaces associates protoName with AccountI and VestingAccount
+// Interfaces and creates a registry of it's concrete implementations.
 func RegisterInterfaces(registry types.InterfaceRegistry) {
 	registry.RegisterInterface(
 		"cosmos.vesting.v1beta1.VestingAccount",

--- a/x/vesting/types/vesting.go
+++ b/x/vesting/types/vesting.go
@@ -11,7 +11,8 @@ var (
 	_ authtypes.GenesisAccount    = (*ClawbackContinuousVestingAccount)(nil)
 )
 
-// NewContinuousVestingAccountRaw creates a new ContinuousVestingAccount object from BaseVestingAccount
+// NewClawbackContinuousVestingAccountRaw creates a new ContinuousVestingAccount
+// object from BaseVestingAccount.
 func NewClawbackContinuousVestingAccountRaw(bva *vestingtypes.BaseVestingAccount, startTime int64, funder string) *ClawbackContinuousVestingAccount {
 	continuousVestingAcc := vestingtypes.NewContinuousVestingAccountRaw(bva, startTime)
 	return &ClawbackContinuousVestingAccount{


### PR DESCRIPTION
Upgrading tallyvm to v2.4.0, which fixes the issue where the vm returns a zero exit code even when the memory allocation exceeds the capacity.