### PR TITLE
chore(ci): upgrade golangci-lint-action to v8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: 1.22.11
           check-latest: true
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout 10m --tests=false --exclude-dirs="e2e"


### PR DESCRIPTION
Maintenance update: switch all jobs to golangci-lint-action@v8 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v8.0.0 release](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0).