### PR TITLE
Update core contract instantiate msg

### DIFF
--- a/app/upgrades/mainnet/v1/constants.go
+++ b/app/upgrades/mainnet/v1/constants.go
@@ -66,15 +66,7 @@ func CreateUpgradeHandler(
 			[]byte(fmt.Sprintf(`{
 				"token":"aseda",
 				"owner": "%s", 
-				"chain_id":"%s",
-				"staking_config": {
-					"minimum_stake": "10",
-					"allowlist_enabled": true
-				},
-				"timeout_config": {
-					"commit_timeout_in_blocks": 10,
-					"reveal_timeout_in_blocks": 5
-				}
+				"chain_id":"%s"
 			}`, securityGroupAddr, ctx.ChainID())),
 			"label", nil)
 		if err != nil {

--- a/x/tally/types/telemetry.go
+++ b/x/tally/types/telemetry.go
@@ -2,4 +2,5 @@ package types
 
 const (
 	TelemetryKeyDataRequestsTallied = "seda_tally_end_block_data_requests_tallied"
+	TelemetryKeyDRFlowHalt          = "seda_tally_end_block_dr_flow_halt"
 )


### PR DESCRIPTION
- Removes core contract parameter values from instantiate msg so that the contract parameters are initialized to the default values defined in the contract.
- Telemetry sets a gauge under key `seda_tally_end_block_dr_flow_halt` to 1 if DR flow halts. It's set back to 0 when `ProcessTallies()` is executed successfully.