### PR TITLE
Correctly process data requests when the contract is paused

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -11,11 +11,13 @@ import (
 	v019 "github.com/sedaprotocol/seda-chain/app/upgrades/mainnet/v0.1.9"
 	v1 "github.com/sedaprotocol/seda-chain/app/upgrades/mainnet/v1"
 	v1rc4 "github.com/sedaprotocol/seda-chain/app/upgrades/testnet/v1.0.0-rc.4"
+	v1rc6 "github.com/sedaprotocol/seda-chain/app/upgrades/testnet/v1.0.0-rc.6"
 )
 
 // Upgrades is a list of currently supported upgrades.
 var Upgrades = []upgrades.Upgrade{
 	v1rc4.Upgrade,
+	v1rc6.Upgrade,
 	v1.Upgrade,
 	v017.Upgrade,
 	v018.Upgrade,

--- a/app/upgrades/testnet/v1.0.0-rc.6/constants.go
+++ b/app/upgrades/testnet/v1.0.0-rc.6/constants.go
@@ -1,0 +1,42 @@
+package v1rc6
+
+import (
+	"context"
+
+	storetypes "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/sedaprotocol/seda-chain/app/keepers"
+	"github.com/sedaprotocol/seda-chain/app/upgrades"
+)
+
+const (
+	UpgradeName = "v1.0.0-rc.6"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}
+
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	_ *keepers.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		// Add additional upgrade logic when needed
+
+		/*
+		 * migrations are run in module name alphabetical
+		 * ascending order, except x/auth which is run last
+		 */
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/x/tally/types/data_result.go
+++ b/x/tally/types/data_result.go
@@ -12,23 +12,37 @@ import (
 // This is used when the request cannot be processed due to an error on our side, as all
 // encoding/decoding of values is done by either the contract or the chain.
 // It triggers a full refund for the poster.
-func MarkResultAsFallback(res *batchingtypes.DataResult, err error) {
+func MarkResultAsFallback(res *batchingtypes.DataResult, encounteredError error) (err error) {
 	gasUsed := math.NewInt(0)
 
 	res.GasUsed = &gasUsed
 	res.ExitCode = TallyExitCodeInvalidRequest
 	res.Consensus = false
-	res.Result = []byte(fmt.Sprintf("unable to process request. error: %s", err.Error()))
+	res.Result = []byte(fmt.Sprintf("unable to process request. error: %s", encounteredError.Error()))
+
+	res.Id, err = res.TryHash()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // MarkResultAsPaused marks a DataResult as a paused result.
 // This is used when the contract is paused and we want to prevent any further processing.
 // It triggers a full refund for the poster.
-func MarkResultAsPaused(res *batchingtypes.DataResult) {
+func MarkResultAsPaused(res *batchingtypes.DataResult) (err error) {
 	gasUsed := math.NewInt(0)
 
 	res.GasUsed = &gasUsed
 	res.ExitCode = TallyExitCodeContractPaused
 	res.Consensus = false
 	res.Result = []byte("contract is paused")
+
+	res.Id, err = res.TryHash()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Motivation

Previously when we introduced the paused contract and fallback results and refactored the payouts we made a mistake which caused the DRs to not be removed from the contract.

## Explanation of Changes

Always create an entry in the processedRequests map (empty slice means full refund)
Have the MarkX methods set the result id
Add the testnet upgrade handler for rc.6

## Testing

Expand on the unit tests to correctly check that no new results are being created and that funds are distributed correctly.

## Related PRs and Issues

N.A.