### PR TITLE
Cleanup temp directories from pre-instantiation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -71,6 +71,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -135,6 +136,7 @@ import (
 	"github.com/sedaprotocol/seda-chain/app/keepers"
 	appparams "github.com/sedaprotocol/seda-chain/app/params"
 	"github.com/sedaprotocol/seda-chain/app/utils"
+
 	// Used in cosmos-sdk when registering the route for swagger docs.
 	_ "github.com/sedaprotocol/seda-chain/client/docs/statik"
 	"github.com/sedaprotocol/seda-chain/cmd/sedad/gentx"
@@ -274,10 +276,8 @@ func NewApp(
 	traceStore io.Writer,
 	loadLatest bool,
 	skipUpgradeHeights map[int64]bool,
-	homePath string,
 	invCheckPeriod uint,
 	appOpts servertypes.AppOptions,
-	wasmDirectory string,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
 	/* =================================================== */
@@ -490,6 +490,7 @@ func NewApp(
 		groupConfig,
 	)
 
+	homePath := cast.ToString(appOpts.Get(flags.FlagHome))
 	// set the governance module account as the authority for conducting upgrades
 	app.UpgradeKeeper = upgradekeeper.NewKeeper(
 		skipUpgradeHeights,
@@ -574,7 +575,7 @@ func NewApp(
 	// Evidence routes and router are set after instantiating SEDA keepers.
 	app.EvidenceKeeper = *evidenceKeeper
 
-	wasmDir := filepath.Join(homePath, wasmDirectory)
+	wasmDir := filepath.Join(homePath, "wasm")
 	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
 	if err != nil {
 		panic(fmt.Sprintf("error while reading wasm config: %s", err))

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -72,7 +72,7 @@ func BenchmarkSimulation(b *testing.B) {
 	})
 
 	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
+	appOptions[flags.FlagHome] = b.TempDir()
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 	appOptions[utils.FlagAllowUnencryptedSEDAKeys] = "true"
 
@@ -82,10 +82,8 @@ func BenchmarkSimulation(b *testing.B) {
 		nil,
 		true,
 		map[int64]bool{},
-		app.DefaultNodeHome,
 		0,
 		appOptions,
-		b.TempDir(),
 		baseapp.SetChainID(config.ChainID),
 	)
 	require.Equal(b, app.Name, bApp.Name())
@@ -135,7 +133,6 @@ func TestAppStateDeterminism(t *testing.T) {
 		appHashList          = make([]json.RawMessage, numTimesToRunPerSeed)
 		appOptions           = make(simtestutil.AppOptionsMap, 0)
 	)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 	appOptions[utils.FlagAllowUnencryptedSEDAKeys] = "true"
 
@@ -151,18 +148,17 @@ func TestAppStateDeterminism(t *testing.T) {
 			}
 			chainID := fmt.Sprintf("chain-id-%d-%d", i, j)
 			config.ChainID = chainID
-
 			db := dbm.NewMemDB()
+			appOptions[flags.FlagHome] = t.TempDir()
+
 			bApp := app.NewApp(
 				logger,
 				db,
 				nil,
 				true,
 				map[int64]bool{},
-				app.DefaultNodeHome,
 				simcli.FlagPeriodValue,
 				appOptions,
-				t.TempDir(),
 				fauxMerkleModeOpt,
 				baseapp.SetChainID(chainID),
 			)
@@ -228,7 +224,7 @@ func TestAppExportImport(t *testing.T) {
 	}()
 
 	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
+	appOptions[flags.FlagHome] = t.TempDir()
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 	appOptions[utils.FlagAllowUnencryptedSEDAKeys] = "true"
 
@@ -238,10 +234,8 @@ func TestAppExportImport(t *testing.T) {
 		nil,
 		true,
 		map[int64]bool{},
-		app.DefaultNodeHome,
 		0,
 		appOptions,
-		t.TempDir(),
 		baseapp.SetChainID(config.ChainID),
 	)
 	require.Equal(t, app.Name, bApp.Name())
@@ -299,10 +293,8 @@ func TestAppExportImport(t *testing.T) {
 		nil,
 		true,
 		map[int64]bool{},
-		app.DefaultNodeHome,
 		0,
 		appOptions,
-		t.TempDir(),
 		baseapp.SetChainID(config.ChainID),
 	)
 	require.Equal(t, app.Name, bApp.Name())
@@ -384,7 +376,7 @@ func TestAppSimulationAfterImport(t *testing.T) {
 	}()
 
 	appOptions := make(simtestutil.AppOptionsMap, 0)
-	appOptions[flags.FlagHome] = app.DefaultNodeHome
+	appOptions[flags.FlagHome] = t.TempDir()
 	appOptions[server.FlagInvCheckPeriod] = simcli.FlagPeriodValue
 	appOptions[utils.FlagAllowUnencryptedSEDAKeys] = "true"
 
@@ -394,10 +386,8 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		nil,
 		true,
 		map[int64]bool{},
-		app.DefaultNodeHome,
 		0,
 		appOptions,
-		t.TempDir(),
 		fauxMerkleModeOpt,
 		baseapp.SetChainID(config.ChainID),
 	)
@@ -461,10 +451,8 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		nil,
 		true,
 		map[int64]bool{},
-		app.DefaultNodeHome,
 		0,
 		appOptions,
-		t.TempDir(),
 		fauxMerkleModeOpt,
 		baseapp.SetChainID(config.ChainID),
 	)


### PR DESCRIPTION
A temporary directory created from pre-instantiation of the application was not being properly clean up. As a result, every run of the application created a directory that never got cleaned up. 

The issue originates from the code borrowed from x/wasmd, which has since been fixed https://github.com/CosmWasm/wasmd/pull/2018. This PR applies this fix.

A minor note: This PR also follows the wasmd standard to use a temp directory as the node home for the pre-instantiation process. Before, we were simply creating a temporary wasm directory under the default node home for pre-instantiation. 
