### PR TITLE
Add SettleCredits message to x/sophon

### DIFF
--- a/x/sophon/keeper/msg_server.go
+++ b/x/sophon/keeper/msg_server.go
@@ -139,14 +139,6 @@ func (m msgServer) EditSophon(goCtx context.Context, msg *types.MsgEditSophon) (
 	return &types.MsgEditSophonResponse{}, nil
 }
 
-func (m msgServer) SettleCredits(_ context.Context, _ *types.MsgSettleCredits) (*types.MsgSettleCreditsResponse, error) {
-	panic("not implemented")
-}
-
-func (m msgServer) SubmitReports(_ context.Context, _ *types.MsgSubmitReports) (*types.MsgSubmitReportsResponse, error) {
-	panic("not implemented")
-}
-
 func (m msgServer) UpdateParams(goCtx context.Context, msg *types.MsgUpdateParams) (*types.MsgUpdateParamsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/sophon/keeper/msg_server_credits.go
+++ b/x/sophon/keeper/msg_server_credits.go
@@ -1,0 +1,93 @@
+package keeper
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strconv"
+
+	"cosmossdk.io/collections"
+	errorsmod "cosmossdk.io/errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/sedaprotocol/seda-chain/x/sophon/types"
+)
+
+func (m msgServer) SettleCredits(goCtx context.Context, msg *types.MsgSettleCredits) (*types.MsgSettleCreditsResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	adminAddr, err := sdk.AccAddressFromBech32(msg.AdminAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeyBytes, err := hex.DecodeString(msg.SophonPublicKey)
+	if err != nil {
+		return nil, errorsmod.Wrapf(err, "invalid hex in pubkey: %s", msg.SophonPublicKey)
+	}
+
+	sophonInfo, err := m.GetSophonInfo(ctx, pubKeyBytes)
+	if err != nil {
+		if errors.Is(err, collections.ErrNotFound) {
+			return nil, sdkerrors.ErrNotFound.Wrapf("sophon not found for %s", msg.SophonPublicKey)
+		}
+		return nil, err
+	}
+
+	if sophonInfo.AdminAddress != msg.AdminAddress {
+		return nil, sdkerrors.ErrorInvalidSigner.Wrapf("invalid admin address; requested %s, available %s", msg.AdminAddress, sophonInfo.AdminAddress)
+	}
+
+	if sophonInfo.UsedCredits.LT(msg.Amount) {
+		return nil, types.ErrInsufficientCredits.Wrapf("unable to settle credits; requested %s, available %s", msg.Amount.String(), sophonInfo.UsedCredits.String())
+	}
+
+	if sophonInfo.Balance.LT(msg.Amount) {
+		return nil, types.ErrInsufficientBalance.Wrapf("unable to settle credits; requested %s, available %s", msg.Amount.String(), sophonInfo.Balance.String())
+	}
+
+	sophonInfo.UsedCredits = sophonInfo.UsedCredits.Sub(msg.Amount)
+	sophonInfo.Balance = sophonInfo.Balance.Sub(msg.Amount)
+
+	denom, err := m.stakingKeeper.BondDenom(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	switch msg.SettleType {
+	case types.SETTLE_TYPE_BURN:
+		err = m.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin(denom, msg.Amount)))
+		if err != nil {
+			return nil, err
+		}
+	case types.SETTLE_TYPE_WITHDRAW:
+		err = m.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, adminAddr, sdk.NewCoins(sdk.NewCoin(denom, msg.Amount)))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = m.SetSophonInfo(ctx, pubKeyBytes, sophonInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeSettleCredits,
+			sdk.NewAttribute(types.AttributeSophonID, strconv.FormatUint(sophonInfo.Id, 10)),
+			sdk.NewAttribute(types.AttributeSophonPubKey, msg.SophonPublicKey),
+			sdk.NewAttribute(types.AttributeSettleType, msg.SettleType.String()),
+			sdk.NewAttribute(types.AttributeCredits, msg.Amount.String()),
+		),
+		createSophonEvent(sophonInfo),
+	})
+
+	return &types.MsgSettleCreditsResponse{}, nil
+}
+
+func (m msgServer) SubmitReports(_ context.Context, _ *types.MsgSubmitReports) (*types.MsgSubmitReportsResponse, error) {
+	panic("not implemented")
+}

--- a/x/sophon/keeper/msg_server_credits_test.go
+++ b/x/sophon/keeper/msg_server_credits_test.go
@@ -1,0 +1,256 @@
+package keeper_test
+
+import (
+	"encoding/hex"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/sedaprotocol/seda-chain/x/sophon/types"
+)
+
+func (s *KeeperTestSuite) TestMsgServer_SettleCreditsWithdraw() {
+	adminAddr := "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5"
+	adminAccAddr, err := sdk.AccAddressFromBech32(adminAddr)
+	s.Require().NoError(err)
+
+	pubKeyHex := "02095af5db08cef43871a4aa48a80bdddc5249e4234e7432c3d7eca14f31261b10"
+	pubKey, err := hex.DecodeString(pubKeyHex)
+	s.Require().NoError(err)
+
+	initialCredits := math.NewInt(1000000000000000000)
+	initialBalance := initialCredits.Mul(math.NewInt(2))
+
+	tests := []struct {
+		name               string
+		msg                *types.MsgSettleCredits
+		expected           *types.SophonInfo
+		expectedBankAmount math.Int
+		wantErr            error
+	}{
+		{
+			name: "Happy path withdraw all credits",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    adminAddr,
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialCredits,
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			expected: &types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance.Sub(initialCredits),
+				UsedCredits:  math.NewInt(0),
+			},
+			expectedBankAmount: initialCredits,
+		},
+		{
+			name: "Happy path withdraw partial credits",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    adminAddr,
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialCredits.Quo(math.NewInt(2)),
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			expected: &types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance.Sub(initialCredits.Quo(math.NewInt(2))),
+				UsedCredits:  initialCredits.Quo(math.NewInt(2)),
+			},
+			expectedBankAmount: initialCredits.Quo(math.NewInt(2)),
+		},
+		{
+			name: "withdraw more than available credits",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    adminAddr,
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialBalance.Add(math.NewInt(1)),
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			expected: &types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance,
+				UsedCredits:  initialBalance,
+			},
+			wantErr: types.ErrInsufficientCredits,
+		},
+		{
+			name: "withdraw with invalid admin address",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh",
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialCredits,
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			wantErr: sdkerrors.ErrorInvalidSigner,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.keeper.SetSophonInfo(s.ctx, pubKey, types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance,
+				UsedCredits:  initialCredits,
+			})
+
+			if test.wantErr == nil {
+				s.bankKeeper.EXPECT().SendCoinsFromModuleToAccount(s.ctx, types.ModuleName, adminAccAddr, sdk.NewCoins(sdk.NewCoin("aseda", test.expectedBankAmount))).Return(nil)
+			}
+
+			response, err := s.msgSrvr.SettleCredits(s.ctx, test.msg)
+			if test.wantErr != nil {
+				s.Require().ErrorIs(err, test.wantErr)
+				s.Require().Nil(response)
+				return
+			}
+
+			s.Require().NoError(err)
+			sophonInfo, err := s.keeper.GetSophonInfo(s.ctx, pubKey)
+			s.Require().NoError(err)
+
+			s.Require().Equal(test.expected, &sophonInfo)
+		})
+	}
+}
+
+func (s *KeeperTestSuite) TestMsgServer_SettleCreditsBurn() {
+	adminAddr := "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5"
+	pubKeyHex := "02095af5db08cef43871a4aa48a80bdddc5249e4234e7432c3d7eca14f31261b10"
+	pubKey, err := hex.DecodeString(pubKeyHex)
+	s.Require().NoError(err)
+
+	initialCredits := math.NewInt(1000000000000000000)
+	initialBalance := initialCredits.Mul(math.NewInt(2))
+
+	tests := []struct {
+		name               string
+		msg                *types.MsgSettleCredits
+		expected           *types.SophonInfo
+		expectedBankAmount math.Int
+		wantErr            error
+	}{
+		{
+			name: "Happy path burn all credits",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    adminAddr,
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialCredits,
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			expected: &types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance.Sub(initialCredits),
+				UsedCredits:  math.NewInt(0),
+			},
+			expectedBankAmount: initialCredits,
+		},
+		{
+			name: "Happy path burn partial credits",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    adminAddr,
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialCredits.Quo(math.NewInt(2)),
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			expected: &types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance.Sub(initialCredits.Quo(math.NewInt(2))),
+				UsedCredits:  initialCredits.Quo(math.NewInt(2)),
+			},
+			expectedBankAmount: initialCredits.Quo(math.NewInt(2)),
+		},
+		{
+			name: "burn more than available credits",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    adminAddr,
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialBalance.Add(math.NewInt(1)),
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			expected: &types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance,
+				UsedCredits:  initialBalance,
+			},
+			wantErr: types.ErrInsufficientCredits,
+		},
+		{
+			name: "burn with invalid admin address",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1wyzxdtpl0c99c92n397r3drlhj09qfjvf6teyh",
+				SophonPublicKey: pubKeyHex,
+				Amount:          initialCredits,
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			wantErr: sdkerrors.ErrorInvalidSigner,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			s.keeper.SetSophonInfo(s.ctx, pubKey, types.SophonInfo{
+				Id:           0,
+				OwnerAddress: adminAddr,
+				AdminAddress: adminAddr,
+				Address:      adminAddr,
+				PublicKey:    pubKey,
+				Memo:         "",
+				Balance:      initialBalance,
+				UsedCredits:  initialCredits,
+			})
+
+			if test.wantErr == nil {
+				s.bankKeeper.EXPECT().BurnCoins(s.ctx, types.ModuleName, sdk.NewCoins(sdk.NewCoin("aseda", test.expectedBankAmount))).Return(nil)
+			}
+
+			response, err := s.msgSrvr.SettleCredits(s.ctx, test.msg)
+			if test.wantErr != nil {
+				s.Require().ErrorIs(err, test.wantErr)
+				s.Require().Nil(response)
+				return
+			}
+
+			s.Require().NoError(err)
+			sophonInfo, err := s.keeper.GetSophonInfo(s.ctx, pubKey)
+			s.Require().NoError(err)
+
+			s.Require().Equal(test.expected, &sophonInfo)
+		})
+	}
+}

--- a/x/sophon/keeper/testutil/expected_keepers_mock.go
+++ b/x/sophon/keeper/testutil/expected_keepers_mock.go
@@ -70,6 +70,20 @@ func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(ctx, senderAd
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), ctx, senderAddr, recipientModule, amt)
 }
 
+// SendCoinsFromModuleToAccount mocks base method.
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr types.AccAddress, amt types.Coins) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendCoinsFromModuleToAccount", ctx, senderModule, recipientAddr, amt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendCoinsFromModuleToAccount indicates an expected call of SendCoinsFromModuleToAccount.
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(ctx, senderModule, recipientAddr, amt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToAccount), ctx, senderModule, recipientAddr, amt)
+}
+
 // MockAccountKeeper is a mock of AccountKeeper interface.
 type MockAccountKeeper struct {
 	ctrl     *gomock.Controller

--- a/x/sophon/types/errors.go
+++ b/x/sophon/types/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrSophonAlreadyExists = errors.Register(ModuleName, 0, "sophon already exists")
 	ErrUserAlreadyExists   = errors.Register(ModuleName, 1, "user already exists")
 	ErrInsufficientCredits = errors.Register(ModuleName, 2, "insufficient credits")
+	ErrInsufficientBalance = errors.Register(ModuleName, 3, "insufficient balance")
 )

--- a/x/sophon/types/events.go
+++ b/x/sophon/types/events.go
@@ -12,6 +12,7 @@ const (
 	EventTypeRemoveUser              = "remove_user"
 	EventTypeTopUpUser               = "top_up_user"
 	EventTypeExpireUserCredits       = "expire_credits"
+	EventTypeSettleCredits           = "settle_credits"
 
 	AttributeSophonPubKey    = "sophon_pub_key"
 	AttributeSophonID        = "sophon_id"
@@ -26,4 +27,5 @@ const (
 	//nolint:gosec // G101: These are not sensitive values
 	AttributeInitialCredits = "user_initial_credits"
 	AttributeCredits        = "credits"
+	AttributeSettleType     = "settle_type"
 )

--- a/x/sophon/types/expected_keepers.go
+++ b/x/sophon/types/expected_keepers.go
@@ -11,6 +11,7 @@ import (
 // BankKeeper defines the contract needed for supply related APIs (noalias)
 type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	BurnCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
 }
 

--- a/x/sophon/types/tx.go
+++ b/x/sophon/types/tx.go
@@ -283,7 +283,36 @@ func (m *MsgExpireUserCredits) ValidateBasic() error {
 }
 
 func (m *MsgSettleCredits) ValidateBasic() error {
-	return fmt.Errorf("not implemented")
+	if _, err := sdk.AccAddressFromBech32(m.AdminAddress); err != nil {
+		return sdkerrors.ErrInvalidAddress.Wrapf("invalid admin address: %s", m.AdminAddress)
+	}
+
+	if len(m.SophonPublicKey) == 0 {
+		return sdkerrors.ErrInvalidRequest.Wrap("empty public key")
+	}
+
+	if len(m.SophonPublicKey) > MaxPublicKeyLength {
+		return sdkerrors.ErrInvalidRequest.Wrapf("public key is too long; got: %d, max < %d", len(m.SophonPublicKey), MaxPublicKeyLength)
+	}
+
+	_, err := hex.DecodeString(m.SophonPublicKey)
+	if err != nil {
+		return sdkerrors.ErrInvalidRequest.Wrapf("invalid hex in pubkey: %s", m.SophonPublicKey)
+	}
+
+	if m.Amount.IsNil() {
+		return sdkerrors.ErrInvalidRequest.Wrap("amount is nil")
+	}
+
+	if !m.Amount.IsPositive() {
+		return sdkerrors.ErrInvalidRequest.Wrap("amount is not positive")
+	}
+
+	if m.SettleType == SETTLE_TYPE_UNSPECIFIED {
+		return sdkerrors.ErrInvalidRequest.Wrap("invalid settle type")
+	}
+
+	return nil
 }
 
 func (m *MsgSubmitReports) ValidateBasic() error {

--- a/x/sophon/types/tx_test.go
+++ b/x/sophon/types/tx_test.go
@@ -839,3 +839,113 @@ func (s *TypesTestSuite) TestMsgExpireUserCredits_ValidateBasic() {
 		})
 	}
 }
+
+func (s *TypesTestSuite) TestMsgSettleCredits_ValidateBasic() {
+	pubKeyHex := "02100efce2a783cc7a3fbf9c5d15d4cc6e263337651312f21a35d30c16cb38f4c3"
+
+	tests := []struct {
+		name    string
+		msg     *types.MsgSettleCredits
+		wantErr error
+	}{
+		{
+			name: "valid withdraw",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: pubKeyHex,
+				Amount:          math.NewInt(1000000000000000000),
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+		},
+		{
+			name: "valid burn",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: pubKeyHex,
+				Amount:          math.NewInt(50000000000),
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+		},
+		{
+			name: "invalid settle type",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: pubKeyHex,
+				Amount:          math.NewInt(50000000000),
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid admin address",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "invalid",
+				SophonPublicKey: pubKeyHex,
+				Amount:          math.NewInt(1000000000000000000),
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			wantErr: sdkerrors.ErrInvalidAddress,
+		},
+		{
+			name: "empty sophon public key",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: "",
+				Amount:          math.NewInt(1000000000000000000),
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "invalid sophon public key",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: "not valid hex",
+				Amount:          math.NewInt(1000000000000000000),
+				SettleType:      types.SETTLE_TYPE_WITHDRAW,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "negative amount",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: pubKeyHex,
+				Amount:          math.NewInt(-1),
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "nil amount",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: pubKeyHex,
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "zero amount",
+			msg: &types.MsgSettleCredits{
+				AdminAddress:    "seda1uea9km4nup9q7qu96ak683kc67x9jf7ste45z5",
+				SophonPublicKey: pubKeyHex,
+				Amount:          math.NewInt(0),
+				SettleType:      types.SETTLE_TYPE_BURN,
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+	}
+
+	for _, test := range tests {
+		s.Run(test.name, func() {
+			err := test.msg.ValidateBasic()
+
+			if test.wantErr != nil {
+				s.Require().ErrorIs(err, test.wantErr)
+				return
+			}
+
+			s.Require().NoError(err)
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Allow administrators to manually settle used credits on the Sophon.

## Explanation of Changes

N.A.

## Testing

Added message validation and handling tests.

## Related PRs and Issues

Part-of: #595
