### PR TITLE
Fix core upgrade handler bug

### DIFF
--- a/app/upgrades/mainnet/v1.1.0/upgrade.go
+++ b/app/upgrades/mainnet/v1.1.0/upgrade.go
@@ -56,9 +56,11 @@ func CreateUpgradeHandler(
 			keyStr := string(key)
 			switch {
 			case strings.Contains(keyStr, "owner"):
-				err := json.Unmarshal(value, &owner)
-				if err != nil {
-					panic(fmt.Sprintf("failed to unmarshal owner: %s", owner))
+				if !strings.Contains(keyStr, "pending_owner") {
+					err := json.Unmarshal(value, &owner)
+					if err != nil {
+						panic(fmt.Sprintf("failed to unmarshal owner: %s", owner))
+					}
 				}
 
 			case strings.Contains(keyStr, "allowlist"):

--- a/x/core/types/staker_indexing.go
+++ b/x/core/types/staker_indexing.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"errors"
+
 	"cosmossdk.io/collections"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -38,7 +40,11 @@ func (s StakerIndexing) Set(ctx sdk.Context, pubKey string, staker Staker) error
 	// and increment the count.
 	count, err := s.count.Get(ctx)
 	if err != nil {
-		return err
+		// The count may not be found if it is accessed without initialization.
+		if !errors.Is(err, collections.ErrNotFound) {
+			return err
+		}
+		count = 0
 	}
 
 	err = s.indexToKey.Set(ctx, count, pubKey)


### PR DESCRIPTION
Taking into account that staker count store is accessed by the upgrade handler without initialization. 
Also, the "owner" key check should be a strict match to avoid matching with "pending_owner".