### PR TITLE
Fix stake counter overwrite bug in upgrade handler

### DIFF
--- a/app/upgrades/mainnet/v1.1.0/upgrade.go
+++ b/app/upgrades/mainnet/v1.1.0/upgrade.go
@@ -42,6 +42,11 @@ func CreateUpgradeHandler(
 	return func(context context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(context)
 
+		versionMap, err := mm.RunMigrations(ctx, configurator, fromVM)
+		if err != nil {
+			return nil, err
+		}
+
 		// Migrate Core Contract state to x/core.
 		contractAddr, err := keepers.WasmStorageKeeper.GetCoreContractAddr(ctx)
 		if err != nil {
@@ -137,6 +142,13 @@ func CreateUpgradeHandler(
 			}
 		}
 
-		return mm.RunMigrations(ctx, configurator, fromVM)
+		ctx.Logger().Info(
+			"Successfully migrated Core Contract state",
+			"owner", owner,
+			"allowlist_len", len(allowlist),
+			"stakers_len", len(stakers),
+		)
+
+		return versionMap, nil
 	}
 }

--- a/app/upgrades/mainnet/v1.1.0/upgrade_test.go
+++ b/app/upgrades/mainnet/v1.1.0/upgrade_test.go
@@ -86,7 +86,7 @@ func TestCoreContractUpgrade(t *testing.T) {
 	require.NoError(t, err)
 
 	moduleManager := testutil.NewMockModuleManager(gomock.NewController(t))
-	moduleManager.EXPECT().RunMigrations(gomock.Any(), gomock.Any(), gomock.Any()).Return(module.VersionMap{}, nil).Times(2)
+	moduleManager.EXPECT().RunMigrations(gomock.Any(), gomock.Any(), gomock.Any()).Return(module.VersionMap{}, nil).Times(3)
 
 	upgradeHandler := v1_1_0.CreateUpgradeHandler(
 		moduleManager, nil,

--- a/x/core/types/staker_indexing.go
+++ b/x/core/types/staker_indexing.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"errors"
-
 	"cosmossdk.io/collections"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -40,11 +38,7 @@ func (s StakerIndexing) Set(ctx sdk.Context, pubKey string, staker Staker) error
 	// and increment the count.
 	count, err := s.count.Get(ctx)
 	if err != nil {
-		// The count may not be found if it is accessed without initialization.
-		if !errors.Is(err, collections.ErrNotFound) {
-			return err
-		}
-		count = 0
+		return err
 	}
 
 	err = s.indexToKey.Set(ctx, count, pubKey)


### PR DESCRIPTION
Execute RunMigrations() before the custom migration logic to prevent RunMigrations's InitGenesis from overwriting the staker counter.

This made PostDataRequest fail after upgrade due to replication factor always exceeding the zero staker count.

### Testing

Local upgrade test and checking PostDataRequest goes through after upgrade.