### PR TITLE
Fix: dr sort order and pagination

### DIFF
--- a/x/core/types/data_request.go
+++ b/x/core/types/data_request.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"strconv"
 )
@@ -25,9 +26,10 @@ func (i DataRequestIndex) Strings() []string {
 	if i == nil || len(i) != 56 {
 		return nil
 	}
+
 	return []string{
 		new(big.Int).SetBytes(i[0:16]).String(),
-		strconv.FormatUint(binary.BigEndian.Uint64(i[16:24]), 10),
+		strconv.FormatUint(math.MaxUint64-uint64(binary.BigEndian.Uint64(i[16:24])), 10),
 		string(i[24:]),
 	}
 }
@@ -51,7 +53,7 @@ func DataRequestIndexFromStrings(strings []string) (DataRequestIndex, error) {
 	if err != nil {
 		return index, fmt.Errorf("invalid height component %s: %w", strings[1], err)
 	}
-	binary.BigEndian.PutUint64(index[16:24], height)
+	binary.BigEndian.PutUint64(index[16:24], math.MaxUint64-height)
 
 	// strings[2] is the dr_id.
 	copy(index[24:], []byte(strings[2]))
@@ -66,7 +68,7 @@ func (dr DataRequest) Index() DataRequestIndex {
 
 	heightBytes := make([]byte, 8)
 	//nolint:gosec // G115: Block height is never negative.
-	binary.BigEndian.PutUint64(heightBytes, uint64(dr.PostedHeight))
+	binary.BigEndian.PutUint64(heightBytes, math.MaxUint64-uint64(dr.PostedHeight))
 
 	drIDBytes := []byte(dr.ID) // TODO or convert hex to bytes?
 	return append(append(priceBytes, heightBytes...), drIDBytes...)

--- a/x/core/types/data_request_indexing.go
+++ b/x/core/types/data_request_indexing.go
@@ -185,12 +185,12 @@ func (s DataRequestIndexing) GetDataRequestsByStatus(ctx sdk.Context, status Dat
 		return nil, nil, 0, err
 	}
 
-	rng := collections.NewPrefixedPairRange[DataRequestStatus, DataRequestIndex](status)
-	if lastSeenIndex != nil {
-		rng.StartExclusive(lastSeenIndex)
-	}
+	// rng := collections.NewPrefixedPairRange[DataRequestStatus, DataRequestIndex](status)
+	// if lastSeenIndex != nil {
+	// 	rng.StartExclusive(lastSeenIndex)
+	// }
 
-	iter, err := s.indexing.Iterate(ctx, rng)
+	iter, err := s.indexing.IterateRaw(ctx, []byte{}, lastSeenIndex, collections.OrderDescending)
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/x/core/types/data_request_indexing.go
+++ b/x/core/types/data_request_indexing.go
@@ -185,12 +185,12 @@ func (s DataRequestIndexing) GetDataRequestsByStatus(ctx sdk.Context, status Dat
 		return nil, nil, 0, err
 	}
 
-	// rng := collections.NewPrefixedPairRange[DataRequestStatus, DataRequestIndex](status)
-	// if lastSeenIndex != nil {
-	// 	rng.StartExclusive(lastSeenIndex)
-	// }
+	rng := collections.NewPrefixedPairRange[DataRequestStatus, DataRequestIndex](status).Descending()
+	if lastSeenIndex != nil {
+		rng.EndExclusive(lastSeenIndex)
+	}
 
-	iter, err := s.indexing.IterateRaw(ctx, []byte{}, lastSeenIndex, collections.OrderDescending)
+	iter, err := s.indexing.Iterate(ctx, rng)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -211,7 +211,7 @@ func (s DataRequestIndexing) GetDataRequestsByStatus(ctx sdk.Context, status Dat
 		}
 
 		dataRequests = append(dataRequests, dataRequest)
-		newLastSeenIndex = key.K2()
+		newLastSeenIndex = append([]byte(nil), key.K2()...)
 		count++
 		if count >= limit {
 			break


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

To have the DRs in the correct order when queried.

## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- The Index was not correctly accounting for the hex difference so lastSeenIndex would be null from strings due to wrong byte length size.
- The Index now properly sorts by oldest block to newest block(height inversion).
- Adjusted the query to do descending order.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

The tests around the query now pass.

## Dependency Chain
[data-proxy]:https://github.com/sedaprotocol/seda-data-proxy
[evm-contracts]:https://github.com/sedaprotocol/seda-evm-contracts
[sdk]: https://github.com/sedaprotocol/seda-sdk
[overlay-rs]: https://github.com/sedaprotocol/overlay-rs
[overlay-ts]: https://github.com/sedaprotocol/seda-overlay-ts
[solver]:https://github.com/sedaprotocol/seda-solver
[chain-indexer-plugin]: https://github.com/sedaprotocol/seda-chain
[explorer/indexer]: https://github.com/sedaprotocol/seda-explorer

Think about the changes (msgs, events, limits, etc.) made in this PR and see if you need to make an issue or a PR on the following repos.

- [ ] [data-proxy][data-proxy]
- [ ] [evm-contracts][evm-contracts]
- [ ] [sdk][sdk]
- [ ] [overlay-rs][overlay-rs]
- [ ] [overlay-ts][overlay-ts]
- [ ] [solver][solver]
- [ ] [chain-indexer-plugin][chain-indexer-plugin]
- [ ] [explorer/indexer][explorer/indexer]


## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Makes progress on https://github.com/sedaprotocol/seda-chain/issues/594.
